### PR TITLE
Fix bgmode switch

### DIFF
--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -2797,17 +2797,9 @@ class PlumeBackground(LoadSaveProcessingSettings):
 
     def save_and_close(self):
         
-        # WHat is the currently set mode?
-        if pyplis_worker.bg_pycam:
-            current_mode = 7
-        else:
-            current_mode = pyplis_worker.plume_bg_A.mode
-
-        # If the selected mode is different than the current mode, then update current mode
-        if self.bg_mode != current_mode:
-            self.gather_vars()
-            pyplis_worker.model_background(plot=False)
-            pyplis_worker.load_sequence(pyplis_worker.img_dir, plot=True, plot_bg=False)
+        self.gather_vars(update_pyplis=True)
+        pyplis_worker.model_background(plot=False)
+        pyplis_worker.load_sequence(pyplis_worker.img_dir, plot=True, plot_bg=False)
         
         # CLose the window
         self.frame.destroy()

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -2051,7 +2051,7 @@ class PlumeBackground(LoadSaveProcessingSettings):
         butt = ttk.Button(butt_frame, text='Set As Defaults', command=lambda: self.set_defaults(parent=self.frame))
         butt.grid(row=0, column=1, sticky='nsew', padx=self.pdx, pady=self.pdy)
 
-        butt = ttk.Button(butt_frame, text='Run', command=self.run_process)
+        butt = ttk.Button(butt_frame, text='Preview', command=self.run_process)
         butt.grid(row=0, column=2, sticky='nsew', padx=self.pdx, pady=self.pdy)
 
         # -----------------------------

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -2788,6 +2788,24 @@ class PlumeBackground(LoadSaveProcessingSettings):
         self.frame.destroy()
         self.in_frame = False
 
+    def save_and_close(self):
+        
+        # WHat is the currently set mode?
+        if pyplis_worker.bg_pycam:
+            current_mode = 7
+        else:
+            current_mode = pyplis_worker.plume_bg_A.mode
+
+        # If the selected mode is different than the current mode, then update current mode
+        if self.bg_mode != current_mode:
+            self.gather_vars()
+            pyplis_worker.model_background(plot=False)
+            pyplis_worker.load_sequence(pyplis_worker.img_dir, plot=True, plot_bg=False)
+        
+        # CLose the window
+        self.frame.destroy()
+        self.in_frame = False
+
     def __draw_canv__(self):
         """Draws canvas periodically"""
         try:

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -2045,7 +2045,7 @@ class PlumeBackground(LoadSaveProcessingSettings):
         butt_frame = ttk.Frame(self.opt_frame)
         butt_frame.grid(row=row, column=0, columnspan=2, padx=5, pady=5, sticky='nsew')
 
-        butt = ttk.Button(butt_frame, text='OK', command=self.close_window)
+        butt = ttk.Button(butt_frame, text='OK', command=self.save_and_close)
         butt.grid(row=0, column=0, sticky='nsew', padx=self.pdx, pady=self.pdy)
 
         butt = ttk.Button(butt_frame, text='Set As Defaults', command=lambda: self.set_defaults(parent=self.frame))


### PR DESCRIPTION
Changes what the 'OK' button does in the 'Background model' window, so that the BG model selected is saved and window closed after pressing 'OK'.

Checks to see if the model selected is the same as currently used/loaded.
- If yes then it just closes the window
- If no, then it runs the model (updating the settings, and plot in analysis window) and then closes the window

__NB:__ This only checks that the BG model selection is the same, if other settings are changed but the BG model isn't then these changes will be lost.

Also, changes the label of the 'Run' button to 'Preview'