### PR TITLE
Add calibration fit statistics

### DIFF
--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -3584,8 +3584,8 @@ class DOASFOVSearchFrame(LoadSaveProcessingSettings):
         self.ax_cal_params_1 = self.fig_cal_params.subplots(1, 1)
         self.ax_cal_params_2 = self.ax_cal_params_1.twinx()
         # self.fig_cal_params.subplots_adjust(left=0.05, right=0.9, top=0.95, bottom=0.05)
-        self.ax_cal_params_1.set_ylabel('Fit 1st order')
-        self.ax_cal_params_2.set_ylabel('Fit error')
+        self.ax_cal_params_1.set_ylabel('Fit 1st order', color = "red")
+        self.ax_cal_params_2.set_ylabel('R squared', color = "blue")
 
         self.frame_cal_params = ttk.Frame(self.frame_plots, relief=tk.RAISED, borderwidth=3)
         self.cal_params_canvas = FigureCanvasTkAgg(self.fig_cal_params, master=self.frame_cal_params)
@@ -3770,10 +3770,15 @@ class DOASFOVSearchFrame(LoadSaveProcessingSettings):
                 print('Calib time: {}'.format(self.pyplis_worker.img_tau.meta['start_acq']))
                 print('Calib coeffs: {}'.format(self.pyplis_worker.calib_pears.calib_coeffs))
                 print('Calib err: {}'.format(self.pyplis_worker.calib_pears.err()))
-                self.ax_cal_params_1.plot(self.pyplis_worker.img_tau.meta['start_acq'],
-                                          self.pyplis_worker.calib_pears.calib_coeffs[0], color='red', marker='o')
-                self.ax_cal_params_2.plot(self.pyplis_worker.img_tau.meta['start_acq'],
-                                          self.pyplis_worker.calib_pears.err(), color='blue', marker='o')
+
+                # Plot slope coefficient
+                self.ax_cal_params_1.plot(self.pyplis_worker.fit_data[:, 0],
+                                          self.pyplis_worker.fit_data[:, 2],
+                                          color='red', marker='o')
+                # Plot R squared value for fit
+                self.ax_cal_params_2.plot(self.pyplis_worker.fit_data[:, 0],
+                                          self.pyplis_worker.fit_data[:, 4],
+                                          color='blue', marker='o')
                 self.ax_cal_params_1.margins(0.05)
                 self.ax_cal_params_2.margins(0.05)
             except (AttributeError, ValueError, TypeError) as e:

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -3584,7 +3584,7 @@ class DOASFOVSearchFrame(LoadSaveProcessingSettings):
         self.ax_cal_params_1 = self.fig_cal_params.subplots(1, 1)
         self.ax_cal_params_2 = self.ax_cal_params_1.twinx()
         # self.fig_cal_params.subplots_adjust(left=0.05, right=0.9, top=0.95, bottom=0.05)
-        self.ax_cal_params_1.set_ylabel('1st order coeff', color = "red")
+        self.ax_cal_params_1.set_ylabel('1st order coefficient', color = "red")
         self.ax_cal_params_2.set_ylabel('R squared', color = "blue")
         self.ax_cal_params_2.set_yticks([0,0.2,0.4,0.6,0.8,1])
         self.ax_cal_params_2.set_ylim(0, 1)
@@ -3776,11 +3776,11 @@ class DOASFOVSearchFrame(LoadSaveProcessingSettings):
                 # Plot slope coefficient
                 self.ax_cal_params_1.plot(self.pyplis_worker.fit_data[:, 0],
                                           self.pyplis_worker.fit_data[:, 2],
-                                          color='red', marker='o',linestyle='none')
+                                          color='red', marker='o', linestyle='none', markersize=3)
                 # Plot R squared value for fit
                 self.ax_cal_params_2.plot(self.pyplis_worker.fit_data[:, 0],
                                           self.pyplis_worker.fit_data[:, 4],
-                                          color='blue', marker='o',linestyle='none')
+                                          color='blue', marker='o', linestyle='none', markersize=3)
                 self.ax_cal_params_1.margins(0.05)
                 self.ax_cal_params_2.margins(0.05)
             except (AttributeError, ValueError, TypeError) as e:

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -3584,8 +3584,10 @@ class DOASFOVSearchFrame(LoadSaveProcessingSettings):
         self.ax_cal_params_1 = self.fig_cal_params.subplots(1, 1)
         self.ax_cal_params_2 = self.ax_cal_params_1.twinx()
         # self.fig_cal_params.subplots_adjust(left=0.05, right=0.9, top=0.95, bottom=0.05)
-        self.ax_cal_params_1.set_ylabel('Fit 1st order', color = "red")
+        self.ax_cal_params_1.set_ylabel('1st order coeff', color = "red")
         self.ax_cal_params_2.set_ylabel('R squared', color = "blue")
+        self.ax_cal_params_2.set_yticks([0,0.2,0.4,0.6,0.8,1])
+        self.ax_cal_params_2.set_ylim(0, 1)
 
         self.frame_cal_params = ttk.Frame(self.frame_plots, relief=tk.RAISED, borderwidth=3)
         self.cal_params_canvas = FigureCanvasTkAgg(self.fig_cal_params, master=self.frame_cal_params)
@@ -3774,11 +3776,11 @@ class DOASFOVSearchFrame(LoadSaveProcessingSettings):
                 # Plot slope coefficient
                 self.ax_cal_params_1.plot(self.pyplis_worker.fit_data[:, 0],
                                           self.pyplis_worker.fit_data[:, 2],
-                                          color='red', marker='o')
+                                          color='red', marker='o',linestyle='none')
                 # Plot R squared value for fit
                 self.ax_cal_params_2.plot(self.pyplis_worker.fit_data[:, 0],
                                           self.pyplis_worker.fit_data[:, 4],
-                                          color='blue', marker='o')
+                                          color='blue', marker='o',linestyle='none')
                 self.ax_cal_params_1.margins(0.05)
                 self.ax_cal_params_2.margins(0.05)
             except (AttributeError, ValueError, TypeError) as e:

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -1966,6 +1966,7 @@ class PyplisWorker:
         s.g2dasym = False  # Allow only circular FOV (not eliptical)
         self.calib_pears = s.perform_fov_search(method='pearson')
         self.calib_pears.fit_calib_data(polyorder=polyorder)
+        self.record_fit_data()
         self.doas_fov_x, self.doas_fov_y = self.calib_pears.fov.pixel_position_center(abs_coords=True)
         self.doas_fov_extent = self.calib_pears.fov.pixel_extend(abs_coords=True)
         self.fov = self.calib_pears.fov
@@ -2198,6 +2199,7 @@ class PyplisWorker:
         # Recalibrate
         if recal:
             self.calib_pears.fit_calib_data()
+            self.record_fit_data()
 
     def rem_doas_cal_data(self, time_obj, inplace=True, recal=True):
         """
@@ -3090,10 +3092,6 @@ class PyplisWorker:
 
             # Save all images that have been requested
             self.save_imgs()
-
-            # If a fit has been produced then save the statistics
-            if self.calib_pears.calib_coeffs is not None:
-                self.record_fit_data()
 
             # Once first image is processed we update the first_image bool
             if i == 0:


### PR DESCRIPTION
Fixes #16 

Plot looks like this (although the right y-axis has the label "R squared")
![image](https://github.com/twVolc/PyCamPermanent/assets/18421270/5de96a48-60f8-4340-812e-7b12c4f7d537)

Two thoughts:
1. Do you want to change the label for the left y-axis?
    - Fit 1st order doesn't mean much to me, but it may be fine for you
2. Do you want to set limits for the right y-axis? 
    - To me the automatically selected limits of this axis makes small changes in R squared look bigger than they are
    - Could set the axes so they have a specific lower bound that allows you to see true dips in fit (e.g. pulling a number from a hat: 0.7)
