### PR TITLE
Run cross corr on every loop after initial run

### DIFF
--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2879,7 +2879,8 @@ class PyplisWorker:
                     self.cross_corr_last = self.img_A.meta['start_acq']
                     time_gap = self.img_A.meta['start_acq'] - self.cross_corr_last
                 time_gap = time_gap.total_seconds() / 60
-                if cross_corr or time_gap >= self.cross_corr_recal:
+
+                if cross_corr or time_gap >= self.cross_corr_recal or self.got_cross_corr:
                     self.generate_cross_corr(self.cross_corr_series['time'],
                                              self.cross_corr_series['young'],
                                              self.cross_corr_series['old'])

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2303,10 +2303,8 @@ class PyplisWorker:
         # plume speed extraction via cross_correlation is needed
         self.cross_corr_last = self.img_A.meta['start_acq']
 
-        # Reset the time series
-        self.cross_corr_series = {'time': [],   # datetime list
-                                  'young': [],  # Young plume series list
-                                  'old': []}    # Old plume series list
+        # Remove first element from time series
+        self.cross_corr_series = {key: np.delete(value, 0) for key, value in self.cross_corr_series.items()}
 
         print('Cross-correlation plume speed results:\n'
               '--------------------------------------\n'


### PR DESCRIPTION
The addition of the `got_cross_corr` flag to this if-statement means that the cross correlation will be re-run on every subsequent image. But I think that the fix for Issue #19 will involve a bit more than just this.