### PR TITLE
Load cal

### DIFF
--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -2857,6 +2857,7 @@ class ProcessSettings(LoadSaveProcessingSettings):
                      'dark_img_dir': str,
                      'dark_spec_dir': str,
                      'cell_cal_dir': str,
+                     'cal_series_path': str,
                      'cal_type_int': int,        # 0 = cell, 1 = doas, 2 = cell + doas
                      'use_sensitivity_mask': int,
                      'use_light_dilution': int,
@@ -2873,8 +2874,9 @@ class ProcessSettings(LoadSaveProcessingSettings):
         self._dark_img_dir = tk.StringVar()
         self._dark_spec_dir = tk.StringVar()
         self._cell_cal_dir = tk.StringVar()
+        self._cal_series_path = tk.StringVar()
         self._cal_type = tk.StringVar()
-        self.cal_opts = ['Cell', 'DOAS', 'Cell + DOAS']
+        self.cal_opts = ['Cell', 'DOAS', 'Cell + DOAS', 'Preloaded']
         self._use_sensitivity_mask = tk.IntVar()
         self._use_light_dilution = tk.IntVar()
         self._min_cd = tk.DoubleVar()
@@ -2954,6 +2956,15 @@ class ProcessSettings(LoadSaveProcessingSettings):
         butt = ttk.Button(path_frame, text='Choose Folder', command=self.get_cell_cal_dir)
         butt.grid(row=row, column=2, sticky='nsew', padx=self.pdx, pady=self.pdy)
         row += 1
+
+        # Cell calibration directory
+        label = ttk.Label(path_frame, text='Calibration time series file:', font=self.main_gui.main_font)
+        label.grid(row=row, column=0, sticky='w', padx=self.pdx, pady=self.pdy)
+        self.cal_series_label = ttk.Label(path_frame, text=self.cal_series_path_short, width=self.path_widg_length,
+                                        font=self.main_gui.main_font, anchor='e')
+        self.cal_series_label.grid(row=row, column=1, padx=self.pdx, pady=self.pdy)
+        butt = ttk.Button(path_frame, text='Choose File', command=self.get_cal_series_path)
+        butt.grid(row=row, column=2, sticky='nsew', padx=self.pdx, pady=self.pdy)
 
         # Processing
         settings_frame = ttk.LabelFrame(self.frame, text='Processing parameters', borderwidth=5)
@@ -3090,6 +3101,21 @@ class ProcessSettings(LoadSaveProcessingSettings):
     def cell_cal_dir_short(self):
         """Returns shorter label for dark directory"""
         return '...' + self.cell_cal_dir[-self.path_str_length:]
+
+    @property
+    def cal_series_path(self):
+        return self._cal_series_path.get()
+
+    @cal_series_path.setter
+    def cal_series_path(self, value):
+        self._cal_series_path.set(value)
+        if hasattr(self, 'cal_series_label') and self.in_frame:
+            self.cal_series_label.configure(text=self.cal_series_path_short)
+
+    @property
+    def cal_series_path_short(self):
+        """Returns shorter label for dark directory"""
+        return '...' + self.cal_series_path[-self.path_str_length:]
 
     @property
     def cal_type(self):
@@ -3244,6 +3270,28 @@ class ProcessSettings(LoadSaveProcessingSettings):
         self.cell_cal_dir = cal_dir
         pyplis_worker.cell_cal_dir = self.cell_cal_dir
 
+    def get_cal_series_path(self, set_var=False):
+        """
+        Gives user options for retrieving cell calibration directory
+        :param set_var: bool
+            If true, this will set the pyplis_worker value automatically. This means that this function can be used
+            from outside of the process_settings widget and the directory will automatically be updated, without
+            requiring the OK click from the settings widget which usually instigates gather_vars. This is used by the
+            menu widget 'Load cell directory' submenu
+        """
+        cal_series_path = filedialog.askopenfilename(initialdir=self.cal_series_path)
+
+        # Pull frame back to the top, as otherwise it tends to hide behind the main frame after closing the filedialog
+        if self.in_frame:
+            self.frame.lift()
+
+        if len(cal_series_path) > 0:
+            self.cal_series_path = cal_series_path
+
+        # Update pyplis worker value if requested (done when using submenu selection
+        if set_var:
+            pyplis_worker.cal_series_path = cal_series_path
+
     def get_bg_file(self, band):
         """Gives user options for retreiving dark directory"""
         bg_file = filedialog.askopenfilename(initialdir=self.dark_img_dir)
@@ -3265,6 +3313,7 @@ class ProcessSettings(LoadSaveProcessingSettings):
         doas_worker.plot_iter = self.plot_iter
         pyplis_worker.dark_dir = self.dark_img_dir       # Load dark_dir prior to bg images - bg images require dark dir
         pyplis_worker.cell_cal_dir = self.cell_cal_dir
+        pyplis_worker.cal_series_path = self.cal_series_path
         pyplis_worker.cal_type = self.cal_type_int
         pyplis_worker.use_sensitivity_mask = bool(self.use_sensitivity_mask)
         pyplis_worker.use_light_dilution = bool(self.use_light_dilution)
@@ -3293,6 +3342,7 @@ class ProcessSettings(LoadSaveProcessingSettings):
         self.dark_img_dir = pyplis_worker.dark_dir
         self.dark_spec_dir = doas_worker.dark_dir
         self.cell_cal_dir = pyplis_worker.cell_cal_dir
+        self.cal_series_path = pyplis_worker.cal_series_path
         self.cal_type_int = pyplis_worker.cal_type
         self.use_sensitivity_mask = int(pyplis_worker.use_sensitivity_mask)
         self.use_light_dilution = int(pyplis_worker.use_light_dilution)

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -3272,12 +3272,12 @@ class ProcessSettings(LoadSaveProcessingSettings):
 
     def get_cal_series_path(self, set_var=False):
         """
-        Gives user options for retrieving cell calibration directory
+        Gives user options for retrieving calibration coefficients from file
         :param set_var: bool
             If true, this will set the pyplis_worker value automatically. This means that this function can be used
             from outside of the process_settings widget and the directory will automatically be updated, without
-            requiring the OK click from the settings widget which usually instigates gather_vars. This is used by the
-            menu widget 'Load cell directory' submenu
+            requiring the OK click from the settings widget which usually instigates gather_vars. This is probably not
+            used anywhere currently
         """
         cal_series_path = filedialog.askopenfilename(initialdir=self.cal_series_path)
 

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -231,7 +231,8 @@ class PyplisWorker:
         self.got_doas_fov = False
         self.got_cal_cell = False
         self._cell_cal_dir = None
-        self.cal_type = 1       # Calibration method: 0 = Cell, 1= DOAS, 2 = Cell and DOAS (cell used to adjust FOV sensitivity)
+        self._cal_series_path = None
+        self.cal_type = 1       # Calibration method: 0 = Cell, 1= DOAS, 2 = Cell and DOAS (cell used to adjust FOV sensitivity), 4 = preloaded coefficients
         self.cell_dict_A = {}
         self.cell_dict_B = {}
         self.cell_tau_dict = {}     # Dictionary holds optical depth images for each cell
@@ -334,6 +335,15 @@ class PyplisWorker:
         """When the cell calibration directory is changed we automatically load it in and process the data"""
         self._cell_cal_dir = value
         self.perform_cell_calibration_pyplis(plot=True)
+
+    @property
+    def cal_series_path(self):
+        return self._cal_series_path
+
+    @cal_series_path.setter
+    def cal_series_path(self, value):
+        self._cal_series_path = value
+        self.load_cal_series(self._cal_series_path)
 
     def update_cam_geom(self, geom_info):
         """Updates camera geometry info by creating a new object and updating MeasSetup object
@@ -1950,6 +1960,22 @@ class PyplisWorker:
 
             cal_img.edit_log["gascalib"] = True
 
+        elif self.cal_type == 3:        # Preloaded calibration coefficients from CSV file
+            if self.calibration_series is None:
+                return cal_img
+
+            # Find closest available calibration data point for current image time
+            closest_index = self.calibration_series.index.get_indexer([self.img_A.meta['start_acq']], method='nearest')
+
+            # Use index to retrieve calibration coeffients
+            grad = self.calibration_series.iloc[closest_index]['coeff 0'][0]
+            intercept = self.calibration_series.iloc[closest_index]['coeff 1'][0]
+
+            # Calibrate image
+            cal_img = img * grad
+            if self.doas_cal_adjust_offset:
+                cal_img = cal_img + intercept
+
         return cal_img
 
     def doas_fov_search(self, img_stack, doas_results, polyorder=1, plot=True, force_save=False):
@@ -2002,7 +2028,7 @@ class PyplisWorker:
 
     def generate_doas_fov(self):
         """
-        Generates clibpears object from fixed DOAS FOV parameters
+        Generates calibpears object from fixed DOAS FOV parameters
         :return:
         """
         self.calib_pears = DoasCalibData(polyorder=self.polyorder_cal, camera=self.cam,
@@ -2225,6 +2251,42 @@ class PyplisWorker:
         if recal:
             calib_dat.fit_calib_data()
         return calib_dat
+
+    def load_cal_series(self, filename):
+        """
+        Loads calibration coefficient time series from a file, to be used to calibrate optical depths.
+        Note: this calibration will be reliant on the optical depths being generated in the same way as when the
+        calibration series was produced - i.e. same background correction scheme - otherwise results are likely to
+        be erroneous.
+        :param filename str Path to calibration file
+        """
+        _, ext = os.path.splitext(filename)
+        if ext != '.csv':
+            print('PyplisWorker.load_cal_series: Cannot read file {} as it is not in the correct format (.csv)'.format(filename))
+            return
+
+        #Extract number of headers
+        with open(filename, 'r') as f:
+            headerline = f.readline()
+            num_headers = int(headerline.split('=')[-1])
+
+        # Load in csv to dataframe
+        self.calibration_series = pd.read_csv(filename, header=num_headers)
+
+        # Set columns to be numeric
+        self.calibration_series = self.calibration_series.astype({'optical depth (tau)': 'float',
+                                                                  'col density (doas)': 'float',
+                                                                  'col density (error)': 'float',
+                                                                  'coeff 0': 'float',
+                                                                  'coeff 1': 'float',
+                                                                  'MSE': 'float',
+                                                                  'r-squared': 'float'})
+
+        # Convert timepoints to datetime objects (easier to work with than time strings)
+        self.calibration_series['timepoint'] = pd.to_datetime(self.calibration_series['timepoint'])
+
+        # Set timepoint as index (useful for searching for times later) and drop rows that don't contain calibration data
+        self.calibration_series = self.calibration_series.set_index('timepoint').dropna()
 
     def calc_line_dist(self, line_1, line_2):
         """

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3409,12 +3409,15 @@ class PyplisWorker:
             file.write('headerlines={}\n'.format(fov_string.count("\n") + 1))  # Adding 1 to account for the header line itself
             file.write(self.generate_DOAS_FOV_info())
 
-        coef_headers = [f"coeff {i}" for i in range(self.polyorder_cal+1)]
+        if hasattr(self, 'calibration_series'):
+            full_df = self.calibration_series
+        else:
+            coef_headers = [f"coeff {i}" for i in range(self.polyorder_cal+1)]
 
-        tau_df = pd.DataFrame(self.tau_vals, columns = ["timepoint", "optical depth (tau)", "col density (doas)", "col density (error)"])
-        fit_df = pd.DataFrame(self.fit_data, columns = ["timepoint"] + coef_headers + ["MSE", "r-squared"])
+            tau_df = pd.DataFrame(self.tau_vals, columns = ["timepoint", "optical depth (tau)", "col density (doas)", "col density (error)"])
+            fit_df = pd.DataFrame(self.fit_data, columns = ["timepoint"] + coef_headers + ["MSE", "r-squared"])
 
-        full_df = pd.merge_asof(tau_df, fit_df, "timepoint")
+            full_df = pd.merge_asof(tau_df, fit_df, "timepoint")
 
         full_df.to_csv(path, mode = "a")
 


### PR DESCRIPTION
This should make it possible to load in the calibration statistics so that calibration of images is more straightforward for subsequent processing runs. It does mean that the camera images must be processed in exactly the same way (same background modelling procedure) otherwise the calibration parameters don't hold. 

Hopefully this is compatible with the new config plans, or at least will be straightforward enough to incorporate into them.

@ubdbra001 I wonder if it's possible for you to run a quick test on this - e.g. load in calibration stats you have previously generated for the Lascar data, then process images exactly as previously done and see if it produces identical emission rates using your written tests? also as discussed, if you check you're happy with the changes in this pull request that would be great.

Calibration stats can be loaded in Processing > Settings > Calibration method [Preloaded], and selecting the csv file in Processing > Settings > Calibration time series file.

It would be nice to plot these data on the calibration fit statistics plot as soon as they are loaded in, so the user can inspect how calibration changes through time.