### PR TITLE
Ifit shift updates

### DIFF
--- a/pycam/conf/processing_setting_defaults.yml
+++ b/pycam/conf/processing_setting_defaults.yml
@@ -97,6 +97,9 @@ dil_recal_time: 30
 use_light_dilution_spec: 0
 grid_max_ppmm: 5000
 grid_increment_ppmm: 20
+LDF: 0.00
 spec_recal_time: 0
 doas_cal_adjust_offset: 0
+
+# Camera Geometry
 default_cam_geom: ./pycam/conf/cam_geom/villarrica_26-03-2018.txt

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -252,6 +252,7 @@ class IFitWorker:
         self.fit_0_uncorr = None
         self.fit_1_uncorr = None
         self.ldf_best = np.nan      # Best estimate of light dilution factor
+        self._LDF = 0               # User-defined LDF to process ifit data with
 
     def reset_self(self, reset_dark=True):
         """Some resetting of object, before processing occurs"""
@@ -390,6 +391,15 @@ class IFitWorker:
 
         # If new ILS is generated, then must flag that ref spectrum is no longer convolved with up-to-date ILS
         self.ref_convolved = False
+
+    @property
+    def LDF(self):
+        return self._LDF
+
+    @LDF.setter
+    def LDF(self, value):
+        self._LDF = value
+        self.analyser.params.add('LDF', value=value, vary=False)
 
     # -------------------------------------------
 

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -5868,6 +5868,7 @@ class LightDilutionSettings(LoadSaveProcessingSettings):
                                    command=lambda: self.gather_vars(rerun_doas=True), font=self.gui.main_font)
         self.LDF_box.grid(row=2, column=1, sticky='ew', padx=2, pady=2)
         if self.use_light_dilution_spec:
+            self.LDF = 0.0
             self.LDF_box.configure(state=tk.DISABLED)
 
 

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -5863,10 +5863,12 @@ class LightDilutionSettings(LoadSaveProcessingSettings):
 
 
         # LDF widget
-        tk.Label(options_frame, text='LDF:', font=self.gui.main_font).grid(row=2, column=0, sticky='w', padx=2, pady=2)
+        tk.Label(options_frame, text='Fix LDF:', font=self.gui.main_font).grid(row=2, column=0, sticky='w', padx=2, pady=2)
         self.LDF_box = ttk.Spinbox(options_frame, from_=0, to=1, increment=0.01, width=4, textvariable=self._LDF,
                                    command=lambda: self.gather_vars(rerun_doas=True), font=self.gui.main_font)
         self.LDF_box.grid(row=2, column=1, sticky='ew', padx=2, pady=2)
+        if self.use_light_dilution_spec:
+            self.LDF_box.configure(state=tk.DISABLED)
 
 
         # Load spectra
@@ -5938,6 +5940,11 @@ class LightDilutionSettings(LoadSaveProcessingSettings):
                                  'Please switch from DOAS to iFit and then attempt correction')
             return
         self.doas_worker.corr_light_dilution = self.use_light_dilution_spec
+        if self.use_light_dilution_spec:
+            self.LDF_box.configure(state=tk.DISABLED)
+            self.LDF = 0.00
+        else:
+            self.LDF_box.configure(state=tk.ACTIVE)
 
     def set_spec_recal(self):
         """Updates doas_worker recalibration time for light dilution factor generation"""

--- a/pycam/gui/figures_doas.py
+++ b/pycam/gui/figures_doas.py
@@ -353,7 +353,7 @@ class DOASPlot(LoadSaveProcessingSettings):
 
         # LDF widget
         tk.Label(self.frame2, text='LDF:', font=self.gui.main_font).pack(side=tk.LEFT)
-        self.LDF_box = ttk.Spinbox(self.frame2, from_=0, to=1, increment=0.01, width=3,
+        self.LDF_box = ttk.Spinbox(self.frame2, from_=0, to=1, increment=0.01, width=4,
                                      textvariable=self._LDF, command=self.gather_vars, font=self.gui.main_font)
         self.LDF_box.pack(side=tk.LEFT)
 

--- a/pycam/gui/figures_doas.py
+++ b/pycam/gui/figures_doas.py
@@ -336,10 +336,10 @@ class DOASPlot:
         self.stretch_box.pack(side=tk.LEFT)
 
         # # If we are working with ifit we don't have these options - it does it automatically
-        # if isinstance(self.doas_worker, IFitWorker):
+        if isinstance(self.doas_worker, IFitWorker):
         #     self.shift_box.configure(state=tk.DISABLED)
-        #     self.shift_tol_box.configure(state=tk.DISABLED)
-        #     self.stretch_box.configure(state=tk.DISABLED)
+            self.shift_tol_box.configure(state=tk.DISABLED)
+            self.stretch_box.configure(state=tk.DISABLED)
 
         # Save button
         self.save_butt = ttk.Button(self.frame2, text='Save spectra', command=self.save_spectra)

--- a/pycam/gui/figures_doas.py
+++ b/pycam/gui/figures_doas.py
@@ -335,11 +335,11 @@ class DOASPlot:
         # self.fit_wind_box_end.grid(row=0, column=3)
         self.stretch_box.pack(side=tk.LEFT)
 
-        # If we are working with ifit we don't have these options - it does it automatically
-        if isinstance(self.doas_worker, IFitWorker):
-            self.shift_box.configure(state=tk.DISABLED)
-            self.shift_tol_box.configure(state=tk.DISABLED)
-            self.stretch_box.configure(state=tk.DISABLED)
+        # # If we are working with ifit we don't have these options - it does it automatically
+        # if isinstance(self.doas_worker, IFitWorker):
+        #     self.shift_box.configure(state=tk.DISABLED)
+        #     self.shift_tol_box.configure(state=tk.DISABLED)
+        #     self.stretch_box.configure(state=tk.DISABLED)
 
         # Save button
         self.save_butt = ttk.Button(self.frame2, text='Save spectra', command=self.save_spectra)

--- a/pycam/gui/figures_doas.py
+++ b/pycam/gui/figures_doas.py
@@ -303,19 +303,15 @@ class DOASPlot(LoadSaveProcessingSettings):
     def initiate_variables(self):
         self.vars = {'shift': int,
                      'shift_tol': int,
-                     'stretch': int,
-                     'LDF': float}
+                     'stretch': int}
 
         self._shift = tk.IntVar()
         self._shift_tol = tk.IntVar()
         self._stretch = tk.IntVar()
-        self._LDF = tk.DoubleVar()
 
         self.shift = self.doas_worker.shift
         self.shift_tol = self.doas_worker.shift_tol
         self.stretch = self.doas_worker.stretch
-        self.LDF = self.doas_worker.LDF
-
 
     def __setup_gui__(self, frame):
         """Organise widget"""
@@ -350,12 +346,6 @@ class DOASPlot(LoadSaveProcessingSettings):
                                        textvariable=self._stretch, command=self.gather_vars)
         # self.fit_wind_box_end.grid(row=0, column=3)
         self.stretch_box.pack(side=tk.LEFT)
-
-        # LDF widget
-        tk.Label(self.frame2, text='LDF:', font=self.gui.main_font).pack(side=tk.LEFT)
-        self.LDF_box = ttk.Spinbox(self.frame2, from_=0, to=1, increment=0.01, width=4,
-                                     textvariable=self._LDF, command=self.gather_vars, font=self.gui.main_font)
-        self.LDF_box.pack(side=tk.LEFT)
 
         # # If we are working with ifit we don't have these options - it does it automatically
         if isinstance(self.doas_worker, IFitWorker):
@@ -438,14 +428,6 @@ class DOASPlot(LoadSaveProcessingSettings):
     def stretch(self, value):
         self._stretch.set(value)
 
-    @property
-    def LDF(self):
-        return self._LDF.get()
-
-    @LDF.setter
-    def LDF(self, value):
-        self._LDF.set(value)
-
     def gather_vars(self):
         """Sets all current settings to the correct worker and reprocesses DOAS"""
         for key in self.vars:
@@ -453,35 +435,6 @@ class DOASPlot(LoadSaveProcessingSettings):
 
         self.doas_worker.process_doas()
         self.update_plot()
-
-    def update_shift_tol(self):
-        """Updates DOASWorker shift value for aligning spectra"""
-        # Set shift in DOASWorker object
-        self.doas_worker.shift_tol = self.shift_tol
-
-        # If we have a processed spectrum we now must update it
-        if self.doas_worker.processed_data:
-            self.doas_worker.process_doas()
-            self.update_plot()
-
-    def update_shift(self):
-        """Updates DOASWorker shift value for aligning spectra"""
-        # Set shift in DOASWorker object
-        self.doas_worker.shift = self.shift.get()
-
-        # If we have a processed spectrum we now must update it
-        if self.doas_worker.processed_data:
-            self.doas_worker.process_doas()
-            self.update_plot()
-
-    def update_stretch(self):
-        """Updates DOASWorker stretch value for aligning spectra"""
-        self.doas_worker.stretch = self.stretch.get()
-
-        # If we have a processed spectrum we now must update it
-        if self.doas_worker.processed_data:
-            self.doas_worker.process_doas()
-            self.update_plot()
 
     def update_plot(self):
         """Updates doas plot"""

--- a/pycam/gui/pycam_gui.py
+++ b/pycam/gui/pycam_gui.py
@@ -124,6 +124,7 @@ class PyCam(ttk.Frame):
         pyplis_worker.doas_worker = doas_worker     # Set DOAS worker to pyplis attribute
         pyplis_worker.load_sequence(pyplis_worker.img_dir, plot_bg=False)
         doas_worker.load_dir(prompt=False, plot=True)
+        doas_worker.process_doas(plot=True)
 
     def exit_app(self):
         """Closes application"""

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -313,7 +313,6 @@ class PyplisWorker:
 
         self.geom_dict = {}
 
-
         self.config = {}
         self.raw_configs = {}
         self.load_config(config_path, "default")
@@ -408,7 +407,8 @@ class PyplisWorker:
             "use_light_dilution_spec": "corr_light_dilution",
             "grid_max_ppmm": "grid_max_ppmm",
             "grid_increment_ppmm": "grid_increment_ppmm",
-            "spec_recal_time": "recal_ld_mins"
+            "spec_recal_time": "recal_ld_mins",
+            "LDF": "LDF"
         }
         
         current_params = {key: getattr(self.doas_worker, value)


### PR DESCRIPTION
Added new iFit functionality:

1.  Can manually shift the spectrum prior to processing - useful for some spectrometers where shifts in calibration are quite large and the iFit built in shift doesn't seem to deal with the issue sufficiently
2. Added functionality to manually set the light dilution factor (LDF) under which all spectra will then be processed. Useful if a location displays quite consistent LDFs - processing this way drastically speeds up processing relative to performing a full LDF calculation for each spectrum.