### PR TITLE
DOAS FOV plot can now be closed

### DIFF
--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -3796,13 +3796,18 @@ class DOASFOVSearchFrame(LoadSaveProcessingSettings):
         except AttributeError:
             pass
 
-    def update_plot(self, update_scat=True, update_img=True, update_params=True):
+    def update_plot(self, update_scat=True, update_img=True, update_params=True, reopen=True):
         """
         Updates plot
+        :param update_scat      bool    If True the scatter plot is updated
+        :param update_image     bool    If True the FOV image is updated
+        :param update_params    bool    If True the calibration stats are updated
+        :param reopen           bool    If True the frame is reopened if it is closed
         :return:
         """
         if not self.in_frame:
-            self.generate_frame()
+            if reopen:
+                self.generate_frame()
             return
 
         # Update FOV variables

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2311,7 +2311,7 @@ class PyplisWorker:
         # Plot results if requested, first checking that we have the tkinter frame generated
         if plot:
             print('Updating DOAS FOV plot')
-            self.fig_doas_fov.update_plot(reopen=False)
+            self.fig_doas_fov.update_plot()
 
     def generate_doas_fov(self):
         """
@@ -2500,7 +2500,7 @@ class PyplisWorker:
                 self.add_doas_cal_data(cal_dict, recal=True)
 
             # Update doas figure, but no need to change the correlation image as we haven't changed that
-            self.fig_doas_fov.update_plot(update_img=False)
+            self.fig_doas_fov.update_plot(update_img=False, reopen=False)
 
     def add_doas_cal_data(self, cal_dict, recal=True):
         """

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2311,7 +2311,7 @@ class PyplisWorker:
         # Plot results if requested, first checking that we have the tkinter frame generated
         if plot:
             print('Updating DOAS FOV plot')
-            self.fig_doas_fov.update_plot()
+            self.fig_doas_fov.update_plot(reopen=False)
 
     def generate_doas_fov(self):
         """


### PR DESCRIPTION
Partly addresses #75 by making it possible to close the DOAS FOV window, but it doesn't identify the root cause of that slow-down which may be useful for the time-series plots too; so I don't think this pull request should close the issue.