### PR TITLE
Fixed fixed FOV GUI bug

### DIFF
--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -3791,7 +3791,7 @@ class DOASFOVSearchFrame(LoadSaveProcessingSettings):
     def update_vars(self):
         """Updates FOV variables based on pyplis worker"""
         try:
-            self.centre_coords = (self.pyplis_worker.centre_pix_x, self.pyplis_worker.centre_pix_x)
+            self.centre_coords = (self.pyplis_worker.centre_pix_x, self.pyplis_worker.centre_pix_y)
             self.fov_rad = self.pyplis_worker.fov_rad
         except AttributeError:
             pass


### PR DESCRIPTION
update_vars() for DOAS FOV had a bug that was setting the y pixel coordinate to be be disaplyed as the x coordinate in the GUI i.e. both x and y were showing the x pixel value