### PR TITLE
Issue 116/display and save config

### DIFF
--- a/pycam/doas/doas_worker.py
+++ b/pycam/doas/doas_worker.py
@@ -461,6 +461,8 @@ class DOASWorker:
             ss = self.spec_dict['plume'][0].split('_')[self.spec_specs.file_ss_loc].replace(ss_id, '')
             self.dark_spec = self.find_dark_spectrum(self.dark_dir, ss)
 
+
+        self.dir_info.update_dir()
         # Update plots if requested
         if plot:
             self.fig_spec.update_clear()

--- a/pycam/doas/doas_worker.py
+++ b/pycam/doas/doas_worker.py
@@ -158,6 +158,7 @@ class DOASWorker:
         # Figures
         self.fig_spec = None            # pycam.doas.SpectraPlot object
         self.fig_doas = None            # pycam.doas.DOASPlot object
+        self.dir_info = None
 
         # Results object
         self.results = DoasResults([], index=[], fit_errs=[], species_id='SO2')

--- a/pycam/doas/doas_worker.py
+++ b/pycam/doas/doas_worker.py
@@ -461,8 +461,10 @@ class DOASWorker:
             ss = self.spec_dict['plume'][0].split('_')[self.spec_specs.file_ss_loc].replace(ss_id, '')
             self.dark_spec = self.find_dark_spectrum(self.dark_dir, ss)
 
-
-        self.dir_info.update_dir()
+        # Only update dir_info widget if it has been initialised
+        if self.dir_info is not None:
+            self.dir_info.update_dir()
+        
         # Update plots if requested
         if plot:
             self.fig_spec.update_clear()

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -674,7 +674,10 @@ class IFitWorker:
             # Try to process first spectrum
             self.process_doas(plot=plot)
 
-        self.dir_info.update_dir()
+        # Only update dir_info widget if it has been initialised
+        if self.dir_info is not None:
+            self.dir_info.update_dir()
+
         # Update plots if requested
         if plot:
             self.fig_spec.update_clear()

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -674,6 +674,7 @@ class IFitWorker:
             # Try to process first spectrum
             self.process_doas(plot=plot)
 
+        self.dir_info.update_dir()
         # Update plots if requested
         if plot:
             self.fig_spec.update_clear()

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -175,6 +175,7 @@ class IFitWorker:
         self.fig_spec = None            # pycam.doas.SpectraPlot object
         self.fig_doas = None            # pycam.doas.DOASPlot object
         self.fig_series = None          # pycam.doas.CDSeries object
+        self.dir_info = None            
 
         # Results object
         self.results = DoasResults([], index=[], fit_errs=[], species_id='SO2')

--- a/pycam/gui/figures_doas.py
+++ b/pycam/gui/figures_doas.py
@@ -26,6 +26,26 @@ plt.style.use('default')
 
 refresh_rate = 200
 
+class DirIndicator:
+    """
+    Class to create widget displaying the current spec_dir in the DOAS window
+    """
+    def __init__(self, main_gui, frame, doas_worker) -> None:
+        """ Initialise and build widget"""
+        self.doas_worker = doas_worker
+        self.doas_worker.dir_info = self
+
+        self.padx = 5
+        self.pady = 5
+
+        self.label = ttk.LabelFrame(frame, text='DOAS directory:',)
+        self.label.grid(row=0, column=1, sticky='nsew', pady=self.pady)
+        self.img_dir_lab = ttk.Label(self.label, text=self.doas_worker.spec_dir, font=main_gui.main_font)
+        self.img_dir_lab.grid(row=0, column=0, sticky='nw', padx=self.padx, pady=self.pady)
+
+    def update_dir(self):
+        """ Update widget with current spec_dir"""
+        self.img_dir_lab.configure(text=self.doas_worker.spec_dir)
 
 class SpectraPlot:
     """

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -755,7 +755,7 @@ class LoadFrame(LoadSaveProcessingSettings):
 
         self.pyplis_worker.apply_config()
         self.pyplis_worker.load_sequence(pyplis_worker.img_dir, plot_bg=False)
-        self.doas_worker.load_dir(prompt=False, plot=True)
+        self.doas_worker.load_dir(self.pyplis_worker.spec_dir, prompt=False, plot=True)
 
     def reset_pcs_lines(self):
         """Reset current PCS lines"""

--- a/pycam/gui/misc.py
+++ b/pycam/gui/misc.py
@@ -322,3 +322,23 @@ class LoadSaveProcessingSettings:
                                               'These will now be the program start-up settings.', **kwargs)
 
 
+class DirIndicator:
+    """
+    Class to create widget displaying the current spec_dir in the DOAS window
+    """
+    def __init__(self, main_gui, frame, doas_worker) -> None:
+        """ Initialise and build widget"""
+        self.doas_worker = doas_worker
+        self.doas_worker.dir_info = self
+
+        self.padx = 5
+        self.pady = 5
+
+        self.label = ttk.LabelFrame(frame, text='DOAS directory:',)
+        self.label.grid(row=0, column=1, sticky='nsew', pady=self.pady)
+        self.img_dir_lab = ttk.Label(self.label, text=self.doas_worker.spec_dir, font=main_gui.main_font)
+        self.img_dir_lab.grid(row=0, column=0, sticky='nw', padx=self.padx, pady=self.pady)
+
+    def update_dir(self):
+        """ Update widget with current spec_dir"""
+        self.img_dir_lab.configure(text=self.doas_worker.spec_dir)

--- a/pycam/gui/misc.py
+++ b/pycam/gui/misc.py
@@ -320,25 +320,3 @@ class LoadSaveProcessingSettings:
             kwargs['parent'] = parent
         messagebox.showinfo('Defaults saved', 'New default settings have been saved.\n '
                                               'These will now be the program start-up settings.', **kwargs)
-
-
-class DirIndicator:
-    """
-    Class to create widget displaying the current spec_dir in the DOAS window
-    """
-    def __init__(self, main_gui, frame, doas_worker) -> None:
-        """ Initialise and build widget"""
-        self.doas_worker = doas_worker
-        self.doas_worker.dir_info = self
-
-        self.padx = 5
-        self.pady = 5
-
-        self.label = ttk.LabelFrame(frame, text='DOAS directory:',)
-        self.label.grid(row=0, column=1, sticky='nsew', pady=self.pady)
-        self.img_dir_lab = ttk.Label(self.label, text=self.doas_worker.spec_dir, font=main_gui.main_font)
-        self.img_dir_lab.grid(row=0, column=0, sticky='nw', padx=self.padx, pady=self.pady)
-
-    def update_dir(self):
-        """ Update widget with current spec_dir"""
-        self.img_dir_lab.configure(text=self.doas_worker.spec_dir)

--- a/pycam/gui/windows.py
+++ b/pycam/gui/windows.py
@@ -4,11 +4,11 @@
 Each window forms a tab which can be accessed through the 'View' menu."""
 
 from .acquisition import CameraSettingsWidget, SpectrometerSettingsWidget
-from .misc import Indicator, ScrollWindow, MessageWindow, DirIndicator
+from .misc import Indicator, ScrollWindow, MessageWindow
 import pycam.gui.cfg as cfg
 from pycam.doas.cfg import doas_worker
 from pycam.gui.figures_cam import ImageFigure, ImageRegistrationFrame
-from pycam.gui.figures_doas import SpectraPlot, DOASPlot, CDSeries
+from pycam.gui.figures_doas import SpectraPlot, DOASPlot, CDSeries, DirIndicator
 from pycam.gui.figures_analysis import ImageSO2, SequenceInfo, TimeSeriesFigure
 
 import tkinter as tk

--- a/pycam/gui/windows.py
+++ b/pycam/gui/windows.py
@@ -4,7 +4,7 @@
 Each window forms a tab which can be accessed through the 'View' menu."""
 
 from .acquisition import CameraSettingsWidget, SpectrometerSettingsWidget
-from .misc import Indicator, ScrollWindow, MessageWindow
+from .misc import Indicator, ScrollWindow, MessageWindow, DirIndicator
 import pycam.gui.cfg as cfg
 from pycam.doas.cfg import doas_worker
 from pycam.gui.figures_cam import ImageFigure, ImageRegistrationFrame
@@ -92,11 +92,12 @@ class SpecWind:
         self.acq_settings = SpectrometerSettingsWidget(self.gui, self.frame)
         self.acq_settings.frame.grid(row=1, column=0, sticky='nw', padx=self.padx, pady=self.pady)
 
+        self.dir_indicator = DirIndicator(self.gui, self.frame, doas_worker)
         # ---------------------------------------
         # Plots
         # ---------------------------------------
         self.scroll_frame = ttk.Frame(self.frame)
-        self.scroll_frame.grid(row=0, column=1, rowspan=3, sticky='nsew')
+        self.scroll_frame.grid(row=1, column=1, rowspan=3, sticky='nsew')
         self.frame.columnconfigure(1, weight=1)
         self.frame.rowconfigure(1, weight=1)
 


### PR DESCRIPTION
Fixes #116 

This adds a frame to display the currently specified `spec_dir` for DOAS
It should also ensure that the updated `spec_dir` (either thought the GUI or a config) is saved to a new config properly.

Not sure if it resolves the previously discussed reset of the Dark Spectra/ Spectra directories, so give it a try and if it doesn't let me know.  