### PR TITLE
Issue 169/handle img load error

### DIFF
--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -41,6 +41,7 @@ import os
 import cv2
 from skimage import transform as tf
 import warnings
+import traceback
 from ruamel.yaml import YAML
 warnings.simplefilter("ignore", UserWarning)
 warnings.simplefilter("ignore", RuntimeWarning)
@@ -3727,8 +3728,13 @@ class PyplisWorker:
 
             # Process image pair
             print('SO2 cam processor: Processing pair: {}'.format(self.img_list[i][0]))
-            self.process_pair(self.img_dir + '\\' + self.img_list[i][0], self.img_dir + '\\' + self.img_list[i][1],
-                              plot=plot_iter, force_cal=force_cal, cross_corr=cross_corr)
+            try:
+                self.process_pair(self.img_dir + '\\' + self.img_list[i][0],
+                                  self.img_dir + '\\' + self.img_list[i][1],
+                                  plot=plot_iter, force_cal=force_cal, cross_corr=cross_corr)
+            except FileNotFoundError:
+                traceback.print_exc()
+                continue
 
             # Save all images that have been requested
             self.save_imgs()
@@ -3821,7 +3827,11 @@ class PyplisWorker:
                     save_last_val_only = False
 
             # Process the pair
-            self.process_pair(img_path_A, img_path_B, plot=self.plot_iter)
+            try:
+                self.process_pair(img_path_A, img_path_B, plot=self.plot_iter)
+            except FileNotFoundError:
+                traceback.print_exc()
+                continue
 
             # Save all images that have been requested
             self.save_imgs()

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3416,12 +3416,17 @@ class PyplisWorker:
         :return:
         """
 
+        # Check to see if the images can be loaded 
+        if img_path_A is not None:
+            img_A = self.get_img(img_path_A, attempts=3)
+        if img_path_B is not None:
+            img_B = self.get_img(img_path_B, attempts=3)
+
         # Can pass None to this function for img paths, and then the current images will be processed
         if img_path_A is not None:
-            # Load in images
-            self.load_img(img_path_A, band='A', plot=plot)
+            self.prep_img(img_A, img_path_A, band='A', plot=plot)
         if img_path_B is not None:
-            self.load_img(img_path_B, band='B', plot=plot)
+            self.prep_img(img_B, img_path_B, band='B', plot=plot)
 
         # Update some initial times which we keep track of throughout
         # Set the cross-correlation time to the first image time, from here we can calculate how long has passed since

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -244,6 +244,7 @@ class PyplisWorker:
         self.img_tau_prev = copy.deepcopy(self.img_A)
         self.img_cal = None         # Calibrated image
         self.img_cal_prev = None
+        self.test_img = copy.deepcopy(self.img_A)
 
         # Calibration attributes
         self.got_doas_fov = False
@@ -3422,6 +3423,12 @@ class PyplisWorker:
             img_A = self.get_img(img_path_A, attempts=3)
         if img_path_B is not None:
             img_B = self.get_img(img_path_B, attempts=3)
+
+        try:
+            img = img_A - self.test_img
+            img = img_B - self.test_img
+        except (TypeError, AttributeError) as e:
+            raise FileNotFoundError('{}'.format(e))
 
         # Can pass None to this function for img paths, and then the current images will be processed
         if img_path_A is not None:


### PR DESCRIPTION
Should fix #169 using the approach discussed in the issue.

Set-up to attempt to load the image a limited number of times before throwing an error and skipping to the next image.
As with #194 there may be some discussion around the number of attempts and how long to wait between attempts, the numbers I picked were out of thin air.