### PR TITLE
Save matplotlib so2 img

### DIFF
--- a/pycam/conf/processing_setting_backup.yml
+++ b/pycam/conf/processing_setting_backup.yml
@@ -34,6 +34,7 @@ ld_lookup_2:
 save_img_aa: 0
 save_img_cal: 0
 save_img_so2: 0
+save_fig_so2: 0
 save_doas_cal: 0
 
 # Plume background model

--- a/pycam/conf/processing_setting_backup.yml
+++ b/pycam/conf/processing_setting_backup.yml
@@ -32,9 +32,13 @@ ld_lookup_2:
 
 # Processing save settings
 save_img_aa: 0
+type_img_aa: .npy
 save_img_cal: 0
+type_img_cal: .npy
 save_img_so2: 0
+png_compression: 0
 save_fig_so2: 0
+type_fig_so2: ppmm
 save_doas_cal: 0
 
 # Plume background model

--- a/pycam/conf/processing_setting_defaults.yml
+++ b/pycam/conf/processing_setting_defaults.yml
@@ -34,6 +34,7 @@ ld_lookup_2:
 save_img_aa: 0
 save_img_cal: 0
 save_img_so2: 0
+save_fig_so2: 0
 save_doas_cal: 0
 
 # Plume background model

--- a/pycam/conf/processing_setting_defaults.yml
+++ b/pycam/conf/processing_setting_defaults.yml
@@ -32,9 +32,13 @@ ld_lookup_2:
 
 # Processing save settings
 save_img_aa: 0
+type_img_aa: .npy
 save_img_cal: 0
+type_img_cal: .npy
 save_img_so2: 0
+png_compression: 0
 save_fig_so2: 0
+type_fig_so2: ppmm
 save_doas_cal: 0
 
 # Plume background model

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -39,6 +39,8 @@ import time
 import queue
 import threading
 from pandas import Series
+import io
+import pickle
 
 refresh_rate = 200    # Refresh rate of draw command when in processing thread
 
@@ -1071,8 +1073,12 @@ class ImageSO2(LoadSaveProcessingSettings):
         filename = '{}_SO2_fig'.format(time_str)
         savepath = os.path.join(savedir, filename)
 
-        # Save matplotlib figure to filepath
-        self.fig.savefig(savepath, bbox_inches='tight')
+        # Save matplotlib figure to filepath. Make copy first to maybe stop white flashing
+        buf = io.BytesIO()
+        pickle.dump(self.fig, buf)
+        buf.seek(0)
+        fig = pickle.load(buf)
+        fig.savefig(savepath, bbox_inches='tight')
 
     def __draw_canv__(self):
         """Draws canvas periodically"""

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -1054,6 +1054,24 @@ class ImageSO2(LoadSaveProcessingSettings):
         if draw:
             self.q.put(1)
 
+    def save_figure(self, savedir=None):
+        """
+        Save matplotlib figure to file
+        param: savedir str      directory to save file in.
+                                If None, directory is taken from PyplisWorker.save_img_dir
+        """
+        # Get save directory
+        if savedir is None:
+            savedir = self.pyplis_worker.saved_img_dir
+
+        # Generate filename based on image time
+        time_str = self.image_tau.meta['start_acq'].strftime(self.pyplis_worker.cam_specs.file_datestr)
+        filename = '{}_SO2_fig'.format(time_str)
+        savepath = os.path.join(savedir, filename)
+
+        # Save matplotlib figure to filepath
+        self.fig.savefig(savepath, bbox_inches='tight')
+
     def __draw_canv__(self):
         """Draws canvas periodically"""
         try:

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -1054,7 +1054,7 @@ class ImageSO2(LoadSaveProcessingSettings):
         if draw:
             self.q.put(1)
 
-    def save_figure(self, savedir=None):
+    def save_figure(self, img_time=None, savedir=None):
         """
         Save matplotlib figure to file
         param: savedir str      directory to save file in.
@@ -1065,7 +1065,9 @@ class ImageSO2(LoadSaveProcessingSettings):
             savedir = self.pyplis_worker.saved_img_dir
 
         # Generate filename based on image time
-        time_str = self.image_tau.meta['start_acq'].strftime(self.pyplis_worker.cam_specs.file_datestr)
+        if img_time is None:
+            img_time = self.pyplis_worker.img_tau.meta['start_acq']
+        time_str = img_time.strftime(self.pyplis_worker.cam_specs.file_datestr)
         filename = '{}_SO2_fig'.format(time_str)
         savepath = os.path.join(savedir, filename)
 

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -853,7 +853,7 @@ class SaveFrame(LoadSaveProcessingSettings):
         self.pyplis_worker.config['save_img_so2'] = self.save_img_so2
         self.pyplis_worker.png_compression = self.png_compression
 
-        self.pyplis_worker.config['save_fig_so2'] = self.save_img_so2
+        self.pyplis_worker.config['save_fig_so2'] = self.save_fig_so2
 
         self.pyplis_worker.config['save_doas_cal'] = self.save_doas_cal
 

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -825,12 +825,17 @@ class SaveFrame(LoadSaveProcessingSettings):
 
         # Objects to save in processing
         self.vars = {'save_img_aa': int,
+                     'type_img_aa': str,
                      'save_img_cal': int,
+                     'type_img_cal': str,
                      'save_img_so2': int,
+                     'png_compression': int,
                      'save_fig_so2': int,
+                     'type_fig_so2': str,
                      'save_doas_cal': int}
 
         self.img_types = ['.npy', '.mat']
+        self.fig_so2_units = ['ppmm', 'tau']
         self._save_img_aa = tk.BooleanVar()
         self._type_img_aa = tk.StringVar()
         self.type_img_aa = self.img_types[0]
@@ -839,6 +844,7 @@ class SaveFrame(LoadSaveProcessingSettings):
         self.type_img_cal = self.img_types[0]
         self._save_img_so2 = tk.BooleanVar()
         self._save_fig_so2 = tk.BooleanVar()
+        self._type_fig_so2 = tk.StringVar()
         self._png_compression = tk.IntVar()
         self.png_compression = 0
 
@@ -846,15 +852,16 @@ class SaveFrame(LoadSaveProcessingSettings):
 
     def gather_vars(self):
         self.pyplis_worker.config['save_img_aa'] = self.save_img_aa
-        self.pyplis_worker.type_img_aa = self.type_img_aa
+        self.pyplis_worker.config['type_img_aa'] = self.type_img_aa
 
         self.pyplis_worker.config['save_img_cal'] = self.save_img_cal
-        self.pyplis_worker.type_img_cal = self.type_img_cal
+        self.pyplis_worker.config['type_img_cal'] = self.type_img_cal
 
         self.pyplis_worker.config['save_img_so2'] = self.save_img_so2
-        self.pyplis_worker.png_compression = self.png_compression
+        self.pyplis_worker.config['png_compression'] = self.png_compression
 
         self.pyplis_worker.config['save_fig_so2'] = self.save_fig_so2
+        self.pyplis_worker.config['type_fig_so2'] = self.type_fig_so2
 
         self.pyplis_worker.config['save_doas_cal'] = self.save_doas_cal
 
@@ -915,6 +922,14 @@ class SaveFrame(LoadSaveProcessingSettings):
     @save_fig_so2.setter
     def save_fig_so2(self, value):
         self._save_fig_so2.set(value)
+
+    @property
+    def type_fig_so2(self):
+        return self._type_fig_so2.get()
+
+    @type_fig_so2.setter
+    def type_fig_so2(self, value):
+        self._type_fig_so2.set(value)
 
     @property
     def png_compression(self):
@@ -1027,7 +1042,11 @@ class SaveFrame(LoadSaveProcessingSettings):
         check.grid(row=row, column=0, sticky='w', padx=self.pdx, pady=self.pdy)
         type_frame = ttk.Frame(self.save_proc_frame, relief=tk.RAISED, borderwidth=3)
         type_frame.grid(row=row, column=1, sticky='nsew', padx=self.pdx, pady=self.pdy)
-        # TODO add DPI option in here??
+        lab = ttk.Label(type_frame, text='Units:', font=self.main_gui.main_font)
+        lab.grid(row=0, column=0, sticky='w')
+        fig_units = ttk.OptionMenu(type_frame, self._type_fig_so2, self.type_fig_so2, *self.fig_so2_units)
+        fig_units.config(width=5)
+        fig_units.grid(row=0, column=1, sticky='nsew', padx=2)
         row += 1
 
         # DOAS fit save

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -744,6 +744,7 @@ class LoadFrame(LoadSaveProcessingSettings):
         self.pyplis_worker.fig_tau.load_defaults()
         self.pyplis_worker.fig_tau.reload_roi()
         self.reload_all()
+        self.main_gui.menu.save_frame.load_defaults()
         geom_settings.load_instrument_setup(self.pyplis_worker.config["default_cam_geom"], show_info=False)
         process_settings.load_defaults()
         plume_bg.load_defaults()

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -826,6 +826,7 @@ class SaveFrame(LoadSaveProcessingSettings):
         self.vars = {'save_img_aa': int,
                      'save_img_cal': int,
                      'save_img_so2': int,
+                     'save_fig_so2': int,
                      'save_doas_cal': int}
 
         self.img_types = ['.npy', '.mat']
@@ -836,6 +837,7 @@ class SaveFrame(LoadSaveProcessingSettings):
         self._type_img_cal = tk.StringVar()
         self.type_img_cal = self.img_types[0]
         self._save_img_so2 = tk.BooleanVar()
+        self._save_fig_so2 = tk.BooleanVar()
         self._png_compression = tk.IntVar()
         self.png_compression = 0
 
@@ -850,6 +852,8 @@ class SaveFrame(LoadSaveProcessingSettings):
 
         self.pyplis_worker.config['save_img_so2'] = self.save_img_so2
         self.pyplis_worker.png_compression = self.png_compression
+
+        self.pyplis_worker.config['save_fig_so2'] = self.save_img_so2
 
         self.pyplis_worker.config['save_doas_cal'] = self.save_doas_cal
 
@@ -902,6 +906,14 @@ class SaveFrame(LoadSaveProcessingSettings):
     @save_img_so2.setter
     def save_img_so2(self, value):
         self._save_img_so2.set(value)
+
+    @property
+    def save_fig_so2(self):
+        return self._save_fig_so2.get()
+
+    @save_fig_so2.setter
+    def save_fig_so2(self, value):
+        self._save_fig_so2.set(value)
 
     @property
     def png_compression(self):
@@ -1007,6 +1019,14 @@ class SaveFrame(LoadSaveProcessingSettings):
         img_types = ttk.Spinbox(type_frame, textvariable=self._png_compression, width=3, from_=0, to=9, increment=1,
                                 font=self.main_gui.main_font)
         img_types.grid(row=0, column=1, sticky='nsew', padx=2)
+        row += 1
+
+        # SO2 matplotlib figure save
+        check = ttk.Checkbutton(self.save_proc_frame, text='Save SO2 figure', variable=self._save_fig_so2)
+        check.grid(row=row, column=0, sticky='w', padx=self.pdx, pady=self.pdy)
+        type_frame = ttk.Frame(self.save_proc_frame, relief=tk.RAISED, borderwidth=3)
+        type_frame.grid(row=row, column=1, sticky='nsew', padx=self.pdx, pady=self.pdy)
+        # TODO add DPI option in here??
         row += 1
 
         # DOAS fit save

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -581,6 +581,14 @@ class PyplisWorker:
         self.save_dict['img_SO2']['save'] = value
 
     @property
+    def save_fig_so2(self):
+        return self.save_dict['fig_SO2']['save']
+
+    @save_fig_so2.setter
+    def save_fig_so2(self, value):
+        self.save_dict['fig_SO2']['save'] = value
+
+    @property
     def png_compression(self):
         return self.save_dict['img_SO2']['compression']
 
@@ -1031,7 +1039,8 @@ class PyplisWorker:
 
         # Save matplotlib SO2 image
         if self.save_dict['fig_SO2']:
-            self.fig_tau.save_figure()
+            self.fig_tau.save_figure(img_time=self.img_tau.meta['start_acq'],
+                                     savedir=self.saved_img_dir)
 
     def load_img(self, img_path, band=None, plot=True, temporary=False):
         """

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -1047,11 +1047,15 @@ class PyplisWorker:
                     if not self.fig_tau.disp_cal:
                         self.fig_tau.disp_cal = 1
                         self.fig_tau.update_plot(self.img_tau, self.img_cal)
+                else:
+                    return
             # If tau is selected we need to set plot if it's in the wrong units
             elif self.save_dict['fig_SO2']['units'] == 'tau':
                 if self.fig_tau.disp_cal:
                     self.fig_tau.disp_cal = 0
                     self.fig_tau.update_plot(self.img_tau, self.img_cal)
+            else:
+                print('Warning! Unrecognised units, SO2 figure not saved!')
             self.fig_tau.save_figure(img_time=self.img_tau.meta['start_acq'],
                                      savedir=self.saved_img_dir)
 
@@ -2469,7 +2473,7 @@ class PyplisWorker:
             tau = tau_fov.mean()
 
             try:
-                timeout = datetime.datetime.now() + datetime.timedelta(seconds = 30)
+                timeout = datetime.datetime.now() + datetime.timedelta(seconds = 1)
                 # Keep retrying to get the cd for current time until timeout
                 while (datetime.datetime.now() < timeout):
                     # Get CD for current time

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2481,7 +2481,7 @@ class PyplisWorker:
             tau = tau_fov.mean()
 
             try:
-                timeout = datetime.datetime.now() + datetime.timedelta(seconds = 1)
+                timeout = datetime.datetime.now() + datetime.timedelta(seconds = 30)
                 # Keep retrying to get the cd for current time until timeout
                 while (datetime.datetime.now() < timeout):
                     # Get CD for current time

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -589,6 +589,14 @@ class PyplisWorker:
         self.save_dict['fig_SO2']['save'] = value
 
     @property
+    def type_fig_so2(self):
+        return self.save_dict['fig_SO2']['units']
+
+    @type_fig_so2.setter
+    def type_fig_so2(self, value):
+        self.save_dict['fig_SO2']['units'] = value
+
+    @property
     def png_compression(self):
         return self.save_dict['img_SO2']['compression']
 

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -284,9 +284,11 @@ class PyplisWorker:
         self.bg_B_path = None
         self.bg_A_path_old = None
 
-        self.save_dict = {'img_aa': {'save': False, 'ext': '.npy'},        # Apparent absorption image
-                          'img_cal': {'save': False, 'ext': '.npy'},       # Calibrated SO2 image
-                          'img_SO2': {'save': False, 'compression': 0}}    # Arbitrary SO2 png image
+        self.save_dict = {'img_aa': {'save': False, 'ext': '.npy'},         # Apparent absorption image
+                          'img_cal': {'save': False, 'ext': '.npy'},        # Calibrated SO2 image
+                          'img_SO2': {'save': False, 'compression': 0},     # Arbitrary SO2 png image
+                          'fig_SO2': {'save': False}                        # matplotlib SO2 image
+                          }
         self.save_freq = [0, 30]     # Frequency of saving data
 
         self.img_A_q = queue.Queue()      # Queue for placing images once loaded, so they can be accessed by the GUI
@@ -1026,6 +1028,10 @@ class PyplisWorker:
                 if isinstance(self.img_tau, pyplis.Img):
                     save_so2_img(self.saved_img_dir, self.img_tau, compression=self.save_dict['img_SO2']['compression'],
                                  max_val=max_val)
+
+        # Save matplotlib SO2 image
+        if self.save_dict['fig_SO2']:
+            self.fig_tau.save_figure()
 
     def load_img(self, img_path, band=None, plot=True, temporary=False):
         """


### PR DESCRIPTION
Fixes https://github.com/twVolc/PyCamPermanent/issues/198 and pretty much acheives https://github.com/twVolc/PyCamPermanent/issues/174 - although saving as images rather than a video. The figure is saved in whatever state the analysis window is currently in, so the user will need to select ppmm in that window for ppmm to be saved.
Future development should make the save option possible so if ppmm is chosen the analysis window is forced to ppmm once a calibration is avaliable, and then these figures begin to be saved.