### PR TITLE
Issue 203/add doas lock

### DIFF
--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -605,10 +605,11 @@ class IFitWorker(SpecWorker):
         fit_errs = np.array(list(compress(self.results.fit_errs, fit_err_idxs)))
         ldfs = np.array(list(compress(self.results.ldfs, fit_err_idxs)))
         if inplace:
-            with self.lock:
-                self.results.drop(indices, inplace=True)
-                self.results.fit_errs = fit_errs
-                self.results.ldfs = ldfs
+            # Note this function is used in PyplisWorker and self.lock is acquired there, so I don't
+            # need to acquire it directly in this function (if we do it would freeze the program.
+            self.results.drop(indices, inplace=True)
+            self.results.fit_errs = fit_errs
+            self.results.ldfs = ldfs
             results = None
         else:
             results = DoasResults(self.results.drop(indices, inplace=False))

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -566,29 +566,30 @@ class IFitWorker(SpecWorker):
         except KeyError:
             cd_err = np.nan
 
-        # Faster append method - seems to work
-        self.results.loc[doas_dict['time']] = cd
-        if isinstance(self.results.fit_errs, list):
-            self.results.fit_errs.append(cd_err)
-        elif isinstance(self.results.fit_errs, np.ndarray):
-            self.results.fit_errs = np.append(self.results.fit_errs, cd_err)
-        else:
-            print('ERROR! Unrecognised datatype for ifit fit errors')
+        with self.lock:
+            # Faster append method - seems to work
+            self.results.loc[doas_dict['time']] = cd
+            if isinstance(self.results.fit_errs, list):
+                self.results.fit_errs.append(cd_err)
+            elif isinstance(self.results.fit_errs, np.ndarray):
+                self.results.fit_errs = np.append(self.results.fit_errs, cd_err)
+            else:
+                print('ERROR! Unrecognised datatype for ifit fit errors')
 
-        # Light dilution
-        try:
-            ldf = doas_dict['LDF']
-        except KeyError:
-            ldf = np.nan
+            # Light dilution
+            try:
+                ldf = doas_dict['LDF']
+            except KeyError:
+                ldf = np.nan
 
-        # If there is no ldf attribute, fill it with nans and then set the most recent value to LDF
-        if not hasattr(self.results, 'ldfs'):
-            self.results.ldfs = [np.nan] * len(self.results.fit_errs)
-            self.results.ldfs[-1] = ldf
-        elif isinstance(self.results.ldfs, list):
-            self.results.ldfs.append(ldf)
-        elif isinstance(self.results.ldfs, np.ndarray):
-            self.results.ldfs = np.append(self.results.ldfs, ldf)
+            # If there is no ldf attribute, fill it with nans and then set the most recent value to LDF
+            if not hasattr(self.results, 'ldfs'):
+                self.results.ldfs = [np.nan] * len(self.results.fit_errs)
+                self.results.ldfs[-1] = ldf
+            elif isinstance(self.results.ldfs, list):
+                self.results.ldfs.append(ldf)
+            elif isinstance(self.results.ldfs, np.ndarray):
+                self.results.ldfs = np.append(self.results.ldfs, ldf)
 
     def rem_doas_results(self, time_obj, inplace=False):
         """
@@ -604,9 +605,10 @@ class IFitWorker(SpecWorker):
         fit_errs = np.array(list(compress(self.results.fit_errs, fit_err_idxs)))
         ldfs = np.array(list(compress(self.results.ldfs, fit_err_idxs)))
         if inplace:
-            self.results.drop(indices, inplace=True)
-            self.results.fit_errs = fit_errs
-            self.results.ldfs = ldfs
+            with self.lock:
+                self.results.drop(indices, inplace=True)
+                self.results.fit_errs = fit_errs
+                self.results.ldfs = ldfs
             results = None
         else:
             results = DoasResults(self.results.drop(indices, inplace=False))

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -100,6 +100,7 @@ class SpecWorker:
         # Processing loop attributes
         self.process_thread = None      # Thread for running processing loop
         self.processing_in_thread = False   # Flags whether the object is processing in a thread or in the main thread - therefore deciding whether plots should be updated herein or through pyplisworker
+        self.lock = threading.Lock()        # Lock for updating self.results in a thread-safe manner
         self.q_spec = queue.Queue()     # Queue where spectra files are placed, for processing herein
         self.q_doas = q_doas
         self.watcher = None

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2269,7 +2269,8 @@ class PyplisWorker:
         if self.cal_type_int in [1, 2]:
             # Perform any necessary DOAS calibration updates
             if doas_update:
-                self.update_doas_calibration(img, force_fov_cal=run_cal_doas)
+                with self.doas_worker.lock:
+                    self.update_doas_calibration(img, force_fov_cal=run_cal_doas)
 
         # TODO test function - I have not confirmed that all types of calibration work yet.
         cal_img = None


### PR DESCRIPTION
Hopefully fixes https://github.com/twVolc/PyCamPermanent/issues/203 by adding a lock which is acquired by `PyplisWorker` and `IFitWorker` when trying to access `IFitWorker.results`.

I currently have this running on the Merapi machine, but the camera has stopped for the day, so we won't find out if #203 is hit again until at least tomorrow. If I've understood the error correctly this should solve it though. Fingers crossed...