### PR TITLE
Stop waiting to update doas calibration if newer data point appears

### DIFF
--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2443,7 +2443,8 @@ class PyplisWorker:
             try:
                 timeout = datetime.datetime.now() + datetime.timedelta(seconds = 30)
                 # Keep retrying to get the cd for current time until timeout
-                while (datetime.datetime.now() < timeout):
+                # Will also exit if a new value with a greater datetime is added
+                while (datetime.datetime.now() < timeout) and not np.any(img_time < self.doas_worker.results.index):
                     # Get CD for current time
                     cd = self.doas_worker.results.get(img_time)
                     if cd is not None: break

--- a/pycam/tests/transfer.py
+++ b/pycam/tests/transfer.py
@@ -8,13 +8,15 @@ from time import sleep
 from re import findall
 import sys
 
-def get_avail_datetimes(source, file_match = "**/*Plume.npy"):
+def get_avail_datetimes(source, file_match = "**/*Plume*"):
     """Get a list of all available unique datetimes"""
-    # Look in dir and list all spec (npy) files
+    # Look in dir and list all files
     spec_files = source.glob(file_match)
-    # Extract datetimes from those spec files
-    dtimes = [findall(r"\d{4}-\d{2}-\d{2}T\d{6}", fname.as_posix())[0]
-              for fname in spec_files]
+    # Extract all unique datetimes from found files
+    dtimes_set = {findall(r"\d{4}-\d{2}-\d{2}T\d{6}", fname.as_posix())[0]
+              for fname in spec_files}
+    # Convert back to list and sort
+    dtimes = sorted(list(dtimes_set))
     return dtimes
 
 def get_files(source, dtime):


### PR DESCRIPTION
Fixes #170 

I opted for the second option. Let me know fi you'd like me to add the first option in this PR too.

This also updates the transfer script so that transfers with missing spectra can be simulated. Previously it would have just skipped the images for that timepoint if there was no spectra. It should also be able to handle/simulate cases where one of the image pair is missing too.