### PR TITLE
Fig tau now plotted if ppmm not available

### DIFF
--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -1057,8 +1057,6 @@ class PyplisWorker:
                     if not self.fig_tau.disp_cal:
                         self.fig_tau.disp_cal = 1
                         self.fig_tau.update_plot(self.img_tau, self.img_cal)
-                else:
-                    return
             # If tau is selected we need to set plot if it's in the wrong units
             elif self.save_dict['fig_SO2']['units'] == 'tau':
                 if self.fig_tau.disp_cal:


### PR DESCRIPTION
If the user requests a ppm.m figure save but there is no calibration data available the figure will now save in its tau form, rather than just not saving the figure. When calibration data become available the figure then shifts to ppm.m as requested.