### PR TITLE
Issue 209/new fix

### DIFF
--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -607,9 +607,10 @@ class IFitWorker(SpecWorker):
         if inplace:
             # Note this function is used in PyplisWorker and self.lock is acquired there, so I don't
             # need to acquire it directly in this function (if we do it would freeze the program.
-            self.results.drop(indices, inplace=True)
-            self.results.fit_errs = fit_errs
-            self.results.ldfs = ldfs
+            with self.lock:
+                self.results.drop(indices, inplace=True)
+                self.results.fit_errs = fit_errs
+                self.results.ldfs = ldfs
             results = None
         else:
             results = DoasResults(self.results.drop(indices, inplace=False))


### PR DESCRIPTION
@ubdbra001 if you're able to test this, both in terms of the standard tests to make sure I haven't broken the calculations in some way and in terms of RTP work to see if it seems to run smoothly, that would be great. If I understand correctly, you don't seem to have encountered the #209 error as frequently as we did in Indonesia, so perhaps this isn't going to be a water tight way of checking that it has both removed the issue and not incorporated other annoying isues as before. I think the best we can do is check it on a large amount of data in the RTP mode, to see what happens.

Essentially all I've done is breakout the lock acuqisition into bitsize chunks within `PyplisWorker.update_doas_calibration()` rather than holding the lock for the entirety of the method execution. This should mean that `IFitWorker.results` can be updated whilst `update_doas_calibration()` is in the while-loop check. If I understand correctly there is the smallest chance of a race condition where the check on the `IFitWorker.results` could be updated between the while-loop check on `so2_camera_processor.py` `line 2488` and acquisition of the lock on the next line. But this seems incredibly unlikely to happen, and also still shouldn't lead to a significant bug even if it does happen, as we're still making sure that the lock is acquired throughout assignment of both `cd` and `cd_err`, which I believe is where the issue was arrising.