### PR TITLE
add action restricting PR target

### DIFF
--- a/.github/workflows/restrict-PR-target.yml
+++ b/.github/workflows/restrict-PR-target.yml
@@ -1,0 +1,15 @@
+name: Restrict base branch
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  restrict-base-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: agaroot-technologies/action-restrict-base-branch@v1.0.2
+        with:
+          rules: |
+            master <- dev*


### PR DESCRIPTION
This adds an action to the repo that will fail if a PR to the `master` branch doesn't contain `dev` at the start.

It won't run for this PR and likely won't run properly until it is incorporated in the `master` branch, but I think doing it this way is okay because a PR into `master` is forthcoming (and easier than faffing about adding commits back to the `dev` branch)