### PR TITLE
Issue 140/preloaded cal rtp

### DIFF
--- a/pycam/exceptions.py
+++ b/pycam/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidCalibration(Exception):
+    """Exception highlighing Invalid calibration choice for processing"""

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -12,6 +12,7 @@ from pycam.doas.cfg import doas_worker
 from pycam.doas.ifit_worker import IFitWorker
 from pycam.so2_camera_processor import UnrecognisedSourceError
 from pycam.utils import make_circular_mask_line, truncate_path
+from pycam.exceptions import InvalidCalibration
 
 from pyplis import LineOnImage, Img
 from pyplis.helpers import make_circular_mask, shifted_color_map
@@ -3339,8 +3340,15 @@ class ProcessSettings(LoadSaveProcessingSettings):
     def save_close(self):
         """Gathers all variables and then closes"""
         self.gather_vars()
+        try:
+            pyplis_worker.apply_config(subset=self.vars.keys())
+        except InvalidCalibration:
+            messagebox.showwarning("Missing Calibration file",
+                                   "The Calibration file specified doesn't exist.\n"
+                                   "Please double check the path or choose a different calibration option.")
+            return
+        
         self.close_window()
-        pyplis_worker.apply_config(subset=self.vars.keys())
         # Reload sequence, to ensure that the updates have been made
         pyplis_worker.load_sequence(pyplis_worker.img_dir, plot=True, plot_bg=False)
         doas_worker.load_dir(prompt=False)

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -393,7 +393,15 @@ class PyMenu:
                 'Please select a different calibration type in\n'
                 'Processing Settings > Setup paths\n'
                 'and try again.')
-
+            
+    def process_sequence(self):
+        try:
+            pyplis_worker.process_sequence()
+        except InvalidCalibration:
+            messagebox.showwarning('Must load calibration',
+                                    'Warning! Preloaded calibration is selected but no '
+                                    'calibration file has been loaded. Please select a file to '
+                                    'load to enable calibration.')
 
 class Settings:
     """Class to control the settings from the GUI toolbar"""

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -16,6 +16,7 @@ from pycam.doas.cfg import doas_worker
 from pycam.setupclasses import FileLocator
 from pycam.networking.ssh import open_ssh, ssh_cmd, close_ssh
 from pycam.utils import truncate_path
+from pycam.exceptions import InvalidCalibration
 
 from pyplis import LineOnImage
 
@@ -222,7 +223,7 @@ class PyMenu:
         tab = 'Real-time Processing'
         keys.append(tab)
         self.menus[tab] = tk.Menu(self.frame, tearoff=0)
-        self.menus[tab].add_command(label="Start Watching Directory", command=pyplis_worker.start_watching_dir)
+        self.menus[tab].add_command(label="Start Watching Directory", command=self.start_watching_dir)
         self.menus[tab].add_command(label="Stop Watching Directory", command=pyplis_worker.stop_watching_dir)
 
         # -------------------------------------------------------------------------------------------------------
@@ -380,6 +381,18 @@ class PyMenu:
         """Stops sequence processing of SO2 camera and DOAS"""
         pyplis_worker.stop_sequence_processing()
         doas_worker.stop_sequence_processing()
+
+    def start_watching_dir(self):
+        try:
+            pyplis_worker.start_watching_dir()
+        except InvalidCalibration:
+            pyplis_worker.stop_watching_dir()
+            messagebox.showerror(
+                'Invalid calibration type',
+                'Error! Preloaded calibration is invalid for real-time processing. \n'
+                'Please select a different calibration type in\n'
+                'Processing Settings > Setup paths\n'
+                'and try again.')
 
 
 class Settings:

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -249,7 +249,7 @@ class PyplisWorker:
         self._cal_series_path = None
         self.sens_mask_opts = [0,2]       # Use sensitivity mask when cal_type_int is set to one of the specified options, 0 = cell, 1 = doas, 2 = cell + doas
         self.use_sensitivity_mask = True  # If true, the sensitivty mask will be used to correct tau images
-        self.cal_type_int = 1             # Calibration method: 0 = Cell, 1= DOAS, 2 = Cell and DOAS (cell used to adjust FOV sensitivity), 4 = preloaded coefficients
+        self.cal_type_int = 1             # Calibration method: 0 = Cell, 1= DOAS, 2 = Cell and DOAS (cell used to adjust FOV sensitivity), 3 = preloaded coefficients
         self.cell_dict_A = {}
         self.cell_dict_B = {}
         self.cell_tau_dict = {}     # Dictionary holds optical depth images for each cell
@@ -3877,6 +3877,9 @@ class PyplisWorker:
             print('Please stop watcher before attempting to start new watch. '
                   'This isssue may be caused by having manual acquisitions running alongside continuous watching')
             return
+
+        if self.cal_type_int == 3:
+            # TODO raise a warning window and exit this function - can't perform RTP with a preloaded calibration
         
         if directory is not None:
             self.watching_dir = directory

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3647,11 +3647,28 @@ class PyplisWorker:
     def process_sequence(self):
         """Start _process_sequence in a thread, so that this can return after starting and the GUI doesn't lock up"""
         self.set_processing_directory(make_dir=True)
+
+        # If a calibration has been preloaded then resave it
+        if self.cal_type_int == 3:
+            self.save_preloaded_cal()
+
         self.save_config_plus(self.processed_dir)
         self.apply_config()
         self.process_thread = threading.Thread(target=self._process_sequence, args=())
         self.process_thread.daemon = True
         self.process_thread.start()
+
+    def save_preloaded_cal(self):
+        """ Save the preloaded calibration series to a file """
+
+        # DB 23-09-2024
+        # I don't think is possible to have a situation where cal_type_int = 3 and
+        # calibration_series is None, but just in case...
+        if self.calibration_series is not None:
+            self.write_calib_headerlines()
+            self.calibration_series.to_csv(self.calibration_file_path, mode = "a")
+        else:
+            raise InvalidCalibration("Preloaded calibration is selected but no calibration has been loaded.")
 
     def _process_sequence(self):
         """

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -10,6 +10,7 @@ from pycam.utils import calc_dt, get_horizontal_plume_speed
 from pycam.io_py import save_img, save_emission_rates_as_txt, save_so2_img, save_so2_img_raw, save_pcs_line, save_light_dil_line
 from pycam.directory_watcher import create_dir_watcher
 from pycam.img_import import load_picam_png
+from pycam.exceptions import InvalidCalibration
 
 import pyplis
 from pyplis import LineOnImage
@@ -3884,12 +3885,7 @@ class PyplisWorker:
             return
 
         if self.cal_type_int == 3:
-            messagebox.showerror('Invalid calibration type', 'Error! Preloaded calibration is invalid for '
-                                                             'real-time processing. \n'
-                                                             'Please select a different calibration type in\n'
-                                                             'Processing Settings > Setup paths\n'
-                                                             'and try again.')
-            return
+            raise InvalidCalibration("Preloaded calibration is invalid for real-time processing")
 
         if directory is not None:
             self.watching_dir = directory

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2619,6 +2619,10 @@ class PyplisWorker:
         be erroneous.
         :param filename str Path to calibration file
         """
+
+        if not os.path.exists(filename):
+            raise InvalidCalibration("Calibration file does not exist")
+
         _, ext = os.path.splitext(filename)
         if ext != '.csv':
             print('PyplisWorker.load_cal_series: Cannot read file {} as it is not in the correct format (.csv)'.format(filename))

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -216,6 +216,7 @@ class PyplisWorker:
         self.doas_last_save = datetime.datetime.now()
         self.doas_last_fov_cal = datetime.datetime.now()
         self.doas_cal_adjust_offset = False   # If True, only use gradient of tau-CD plot to calibrate optical depths. If false, the offset is used too (at times could be useful as someimes the background (clear sky) of an image has an optical depth offset (is very negative or positive)
+        self.calibration_series = None          # Series for preloaded calibration
 
         self.img_dir = None
         self.proc_name = 'Processed_{}'     # Directory name for processing
@@ -625,8 +626,8 @@ class PyplisWorker:
     def cal_type_int(self, value):
         self._cal_type_int = value
         self.use_sensitivity_mask = value in self.sens_mask_opts
-        if (value != 3) and hasattr(self, 'calibration_series'):
-            delattr(self, 'calibration_series')
+        if value != 3:
+            self.calibration_series = None
 
     @property
     def nadeau_line_orientation(self):
@@ -2316,6 +2317,10 @@ class PyplisWorker:
 
         elif self.cal_type_int == 3:        # Preloaded calibration coefficients from CSV file
             if self.calibration_series is None:
+                messagebox.showwarning('Must load calibration',
+                                       'Warning! Preloaded calibration is selected but no '
+                                       'calibration file has been loaded. Please select a file to '
+                                       'load to enable calibration.')
                 return cal_img
 
             # Find closest available calibration data point for current image time
@@ -3879,8 +3884,13 @@ class PyplisWorker:
             return
 
         if self.cal_type_int == 3:
-            # TODO raise a warning window and exit this function - can't perform RTP with a preloaded calibration
-        
+            messagebox.showerror('Invalid calibration type', 'Error! Preloaded calibration is invalid for '
+                                                             'real-time processing. \n'
+                                                             'Please select a different calibration type in\n'
+                                                             'Processing Settings > Setup paths\n'
+                                                             'and try again.')
+            return
+
         if directory is not None:
             self.watching_dir = directory
 

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2317,12 +2317,6 @@ class PyplisWorker:
             cal_img.edit_log["gascalib"] = True
 
         elif self.cal_type_int == 3:        # Preloaded calibration coefficients from CSV file
-            if self.calibration_series is None:
-                messagebox.showwarning('Must load calibration',
-                                       'Warning! Preloaded calibration is selected but no '
-                                       'calibration file has been loaded. Please select a file to '
-                                       'load to enable calibration.')
-                return cal_img
 
             # Find closest available calibration data point for current image time
             closest_index = self.calibration_series.index.get_indexer([self.img_A.meta['start_acq']], method='nearest')


### PR DESCRIPTION
This is an update to PR #193. I rebased the branch on the latest dev commit and resolved the merge conflict, but couldn't push the changes to the open PR (due git history differences).

As discussed in #193 I've added an exception to Pyplisworker and moved the error box to the GUI, which is shown when the exception is raised and caught.

I've also added a warning in the GUI if the user tries to select the preloaded calibration but without specifying a valid file path. It will keep the user there until they provide a valid file or choose a different calibration type.

The last thing that may need resolving is when a user tries to load a config file where `cal_type_int` is 3 but the filename provided doesn't exist. Currently this throws an error but is not handled anywhere. I think it fits in with #124 / #141 so may be better handled within that fix?

