### PR TITLE
update PR check rules again

### DIFF
--- a/.github/workflows/restrict-PR-target.yml
+++ b/.github/workflows/restrict-PR-target.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           rules: |
             master <- dev*
+            dev* <- *


### PR DESCRIPTION
Missing rule for merging into `dev` causing failures.
This should fix that 🤞 