### PR TITLE
PR branch checker - Third time lucky

### DIFF
--- a/.github/workflows/restrict-PR-target.yml
+++ b/.github/workflows/restrict-PR-target.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           rules: |
             master <- dev*
-            dev* <- *
+            dev* <- */* *


### PR DESCRIPTION
I think this will finally work now.
Apparently `/` doesn't fall under the wildcard (`*`)