### PR TITLE
Provide feedback when config loading fails

### DIFF
--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -799,6 +799,11 @@ class LoadFrame(LoadSaveProcessingSettings):
             cfg.current_dir_img.root_dir = ftp_output_dir
             cfg.current_dir_spec.root_dir = ftp_output_dir
 
+        if pyplis_worker.missing_path_param_warn is not None:
+            messagebox.showwarning("Missing path params not updated",
+                                   pyplis_worker.missing_path_param_warn)
+            pyplis_worker.missing_path_param_warn = None
+
     def reset_pcs_lines(self):
         """Reset current PCS lines"""
 

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -25,6 +25,7 @@ import tkinter.ttk as ttk
 from tkinter import filedialog
 from tkinter import messagebox
 from shutil import copyfile
+from inspect import cleandoc
 import os
 import threading
 
@@ -755,7 +756,18 @@ class LoadFrame(LoadSaveProcessingSettings):
                 initialdir=self.init_dir)
         
         if len(filename) > 0:
-            self.pyplis_worker.load_config(filename, "user")
+            try:
+                self.pyplis_worker.load_config(filename, "user")
+            except FileNotFoundError as e:
+                error_msg = cleandoc(
+                    f"""
+                    Config load unsuccessful\n
+                    Error: {e}
+                    """)
+
+                messagebox.showerror("Config load failure",
+                                     error_msg)
+                return
 
             self.reload_config()
 

--- a/pycam/gui/pycam_gui.py
+++ b/pycam/gui/pycam_gui.py
@@ -134,6 +134,11 @@ class PyCam(ttk.Frame):
             cfg.current_dir_img.root_dir = ftp_output_dir
             cfg.current_dir_spec.root_dir = ftp_output_dir
 
+        if pyplis_worker.load_default_conf_errors is not None:
+            messagebox.showwarning("Default Config Error",
+                                   pyplis_worker.load_default_conf_errors)
+            pyplis_worker.load_default_conf_errors = None
+
     def exit_app(self):
         """Closes application"""
         if messagebox.askokcancel("Quit", "Are you sure you want to quit?"):

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -369,6 +369,9 @@ class PyplisWorker:
         # (specified by a path relative to pycam location)
         if not os.path.isabs(config_dir):
             return path
+        
+        if path == '':
+            raise FileNotFoundError("Path not specified")
         # If it's an absolute path then just use as is
         elif os.path.isabs(path):
             return path

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -354,10 +354,12 @@ class PyplisWorker:
             # Not the most elegent way to do this, but it'll do for now.
             if type(config_value) is str:
                 new_value = self.expand_config_path(config_value, config_dir)
+                self.check_path(new_value)
                 self.config[path_param] = new_value
             else:
                 for idx, val in enumerate(config_value):
                     new_value = self.expand_config_path(val, config_dir)
+                    self.check_path(new_value)
                     self.config[path_param][idx] = new_value
 
     def expand_config_path(self, path, config_dir):
@@ -376,6 +378,10 @@ class PyplisWorker:
         # Otherwise prepend the path with the location of the config file
         else:
             return os.path.join(config_dir, path)
+
+    def check_path(self, path):
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"File path {path} does not exist")
 
     def save_all_pcs(self, save_dir):
         """Save all the currently loaded/drawn pcs lines to files and update config"""


### PR DESCRIPTION
Fixes #141

This makes sure that the paths specified in the config file actually exist. If not there are two different behaviours depending on when the config file is being loaded:
1. If it is the when PyCam starts (i.e. the default config) then it will fall back to the config file that is supplied with PyCam, and show a warning box once the GUI has loaded (it will also print a warning in the console).
2. If it is when a user config is loaded, then it will display an error box and will keep the currently loaded config. If running without a GUI it will just throw an exception.

The actual messages may need some work.