### PR TITLE
Fix Nadeau frame bug

### DIFF
--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -5638,6 +5638,7 @@ class PlumeVelocityFrame:
         self.in_frame = False
         self.opti_flow.in_frame = False
         self.cross_corr.in_frame = False
+        self.nadeau_flow.in_frame = False
 
         self.cross_corr.update_variables()
         self.nadeau_flow.update_variables()


### PR DESCRIPTION
Fixes #231 by making `in_frame=False` when the plume velocity settings frame is closed.