### PR TITLE
add function for calculating ICA masses

### DIFF
--- a/pycam/io_py.py
+++ b/pycam/io_py.py
@@ -328,11 +328,13 @@ def save_so2_img(path, img, filename=None, compression=0, max_val=None):
     cv2.imwrite(full_path, im2save, png_compression)
 
 
-def save_emission_rates_as_txt(path, emission_dict, only_last_value=False):
+def save_emission_rates_as_txt(path, emission_dict, ICA_dict, only_last_value=False):
     """
     Saves emission rates as text files every hour - emission rates are split into hour-long
     :param path:            str     Directory to save to
     :param emission_dict:   dict    Dictionary of emission rates for different lines and different flow modes
+                                    Assumed to be time-sorted
+    :param ICA_dict         dict    Dictionary of ICA masses for different lines
                                     Assumed to be time-sorted
     :param only_last_value: bool    If True, add only the most recent values to the output file
     :return:
@@ -360,7 +362,13 @@ def save_emission_rates_as_txt(path, emission_dict, only_last_value=False):
         except BaseException as e:
             print('Could not save emission rate data as path definition is not valid:\n'
                   '{}'.format(e))
-                
+        
+        index = -1 if only_last_value else 0
+
+        ICA_masses_df = DataFrame(ICA_dict[line_id]['value'][index:],
+                                  index = ICA_dict[line_id]['datetime'][index:],
+                                  columns = ["ICA_mass_(kg/m)"])
+
         for flow_mode in emission_dict[line_id]:
             emis_dict = emission_dict[line_id][flow_mode]
             # Check there is data in this dictionary - if not, we don't save this data
@@ -380,6 +388,8 @@ def save_emission_rates_as_txt(path, emission_dict, only_last_value=False):
                 # Convert emis_dict object to dataframe
                 emission_df = emis_dict.to_pandas_dataframe()
                 header = True
+
+            emission_df = emission_df.join(ICA_masses_df)
 
             # Round to 3 decimal places
             emission_df = emission_df.round(3)

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3164,7 +3164,7 @@ class PyplisWorker:
                 self.results['total'][mode]._velo_eff[time_idx] = velo_eff_tot
                 self.results['total'][mode]._velo_eff_err[time_idx] = velo_eff_err_tot
             else:
-                self.results['total'][mode]._start_acq.append(img_time_tot)
+                self.results['total'][mode]._start_acq.append(img_time)
                 self.results['total'][mode]._phi.append(phi_tot)
                 self.results['total'][mode]._phi_err.append(phi_err_tot)
                 self.results['total'][mode]._velo_eff.append(velo_eff_tot)

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -969,6 +969,7 @@ class PyplisWorker:
         
         # Add EmissionRates objects for the total emission rates (sum of all lines)
         self.results['total'] = {}
+        self.ICA_masses['total'] = {"datetime": [], "value": []}
         for mode in self.velo_modes:
             self.results['total'][mode] = EmissionRates('total', mode)
 
@@ -3325,6 +3326,8 @@ class PyplisWorker:
                            'flow_histo': {'phi': [], 'phi_err': [], 'veff': [], 'veff_err': []},
                            'flow_hybrid': {'phi': [], 'phi_err': [], 'veff': [], 'veff_err': []},
                            'flow_nadeau': {'phi': [], 'phi_err': [], 'veff': [], 'veff_err': []}}
+        
+        ICA_mass_total = 0
 
         # Get IDs of all lines we want to add up to give the total emissions (basically exclude cross-correlation line)
         lines_total = [line.line_id for line in self.PCS_lines if isinstance(line, LineOnImage)]
@@ -3377,6 +3380,8 @@ class PyplisWorker:
 
                 ICA_mass = self.calculate_ICA_mass(cds, distarr)
                 self.update_ICA_masses(line_id, img_time, ICA_mass)
+
+                if line_include: ICA_mass_total += ICA_mass
 
                 if flow is not None:
                     delt = flow.del_t
@@ -3574,6 +3579,8 @@ class PyplisWorker:
                 self.results['total'][mode]._velo_eff.append(np.nanmean(total_emissions[mode]['veff']))
                 self.results['total'][mode]._velo_eff_err.append(
                     np.sqrt(np.nansum(np.power(total_emissions[mode]['veff_err'], 2))))
+
+        self.update_ICA_masses('total', img_time, ICA_mass_total)
 
         if plot:
             self.fig_series.update_plot()

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3238,6 +3238,19 @@ class PyplisWorker:
                     get_horizontal_plume_speed(self.opt_flow, self.dist_img_step, self.PCS_lines_all[0], filename=filename)
 
         return self.flow, self.velo_img
+    
+    @staticmethod
+    def calculate_ICA_mass(cds, distarr):
+        """ Caluculate the SO2 mass for given column densities and pixel distances
+
+        :param numpy.array cds: Array of estimated column densities for each pixel in ICA line 
+        :param numpy.array distarr: Array of pixel distance values
+        :return float: Estimate of SO2 mass (kg/m) for the ICA line
+        """
+        C = 100**2 * MOL_MASS_SO2 / N_A
+        ICA_Mass = (np.nansum(cds * distarr) * C) / 1000
+
+        return ICA_Mass
 
     def calculate_emission_rate(self, img, flow=None, nadeau_speed=None, plot=True):
         """
@@ -3333,6 +3346,8 @@ class PyplisWorker:
                 props = LocalPlumeProperties(line.line_id)    # Plume properties local to line
                 verr = None                 # Used and redefined later in flow_histo/flow_hybrid
                 dx, dy = None, None         # Generated later. Instantiating here optimizes by preventing repeats later
+
+                ICA_Mass = self.calculate_ICA_mass(cds, distarr) 
 
                 # Cross-correlation emission rate retrieval
                 if self.velo_modes['flow_glob']:

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -173,6 +173,7 @@ class PyplisWorker:
         self.lightcorr_A = None                         # Light dilution corrected image
         self.lightcorr_B = None                         # Light dilution corrected image
         self.results = {}
+        self.ICA_masses = {}
         self.init_results()
 
         # Some pyplis tracking parameters
@@ -964,7 +965,8 @@ class PyplisWorker:
             if line is not None:
                 line_id = line.line_id
                 self.add_line_to_results(line_id)
-
+                self.ICA_masses[line_id] = {"datetime": [], "value": []}
+        
         # Add EmissionRates objects for the total emission rates (sum of all lines)
         self.results['total'] = {}
         for mode in self.velo_modes:
@@ -3373,7 +3375,8 @@ class PyplisWorker:
                 verr = None                 # Used and redefined later in flow_histo/flow_hybrid
                 dx, dy = None, None         # Generated later. Instantiating here optimizes by preventing repeats later
 
-                ICA_Mass = self.calculate_ICA_mass(cds, distarr) 
+                ICA_mass = self.calculate_ICA_mass(cds, distarr)
+                self.update_ICA_masses(line_id, img_time, ICA_mass)
 
                 if flow is not None:
                     delt = flow.del_t
@@ -3576,6 +3579,16 @@ class PyplisWorker:
             self.fig_series.update_plot()
 
         return self.results
+    
+    def update_ICA_masses(self, line_id, img_time, ICA_mass):
+        """Append ICA mass result to results dictionary
+
+        :param str line_id: ID of line ICA mass generated for
+        :param datetime img_time: Timepoint for ICA mass
+        :param float ICA_mass: Value of ICA mass
+        """
+        self.ICA_masses[line_id]["datetime"].append(img_time)
+        self.ICA_masses[line_id]["value"].append(ICA_mass)
 
     @staticmethod
     def det_emission_rate_kgs(*args, **kwargs):

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -4267,7 +4267,8 @@ class PyplisWorker:
         self.stop_watching()
 
     def save_results(self, only_last_value=False):
-        save_emission_rates_as_txt(self.processed_dir, self.results, only_last_value=only_last_value)
+        save_emission_rates_as_txt(self.processed_dir, self.results, self.ICA_masses,
+                                   only_last_value=only_last_value)
         
         # Calibration only produced when DOAS in calibration type and not needed for pre-loaded
         if self.cal_type_int in [1,2]:


### PR DESCRIPTION
Fixes #233 

Need to:
- [x] Add function
- [x] Add to `calculate_emission_rates`
- [ ] ~Add to `get_cross_corr_emissions_from_buff`~ - Not needed due to how values are recorded and added to the output
- [x] Calculate total ICA mass for lines
- [x] Add value to results
- [ ] ~Add test?~

Adds function to calculate ICA_mass for each PCA/ICA line, plus the total.
Adds the results to the emission rate output files.

Some reorganisation of `calculate_emission_rates()` to simplify code.

Test skipped until after separation of config methods from `PyplisWorker`