### PR TITLE
Don't save empty rows in `line_total` `flow_glob` output

### DIFF
--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3125,13 +3125,24 @@ class PyplisWorker:
         # Loop through results dictionary and add the 'total' measurements
         mode = 'flow_glob'
         for i, img_time in enumerate(total_emissions['time']):
-            self.results['total'][mode]._start_acq.append(img_time)
-            self.results['total'][mode]._phi.append(np.nansum(total_emissions['phi'][i]))
-            self.results['total'][mode]._phi_err.append(
-                np.sqrt(np.nansum(np.power(total_emissions['phi_err'][i], 2))))
-            self.results['total'][mode]._velo_eff.append(np.nanmean(total_emissions['veff'][i]))
-            self.results['total'][mode]._velo_eff_err.append(
-                np.sqrt(np.nansum(np.power(total_emissions['veff_err'][i], 2))))
+
+            phi_tot = np.nansum(total_emissions['phi'][i])
+            phi_err_tot = np.sqrt(np.nansum(np.power(total_emissions['phi_err'][i], 2)))
+            velo_eff_tot = np.nanmean(total_emissions['veff'][i])
+            velo_eff_err_tot = np.sqrt(np.nansum(np.power(total_emissions['veff_err'][i], 2)))
+
+            if img_time in self.results['total'][mode]._start_acq:
+                time_idx = self.results['total'][mode]._start_acq.index(img_time)
+                self.results['total'][mode]._phi[time_idx] = phi_tot
+                self.results['total'][mode]._phi_err[time_idx] = phi_err_tot
+                self.results['total'][mode]._velo_eff[time_idx] = velo_eff_tot
+                self.results['total'][mode]._velo_eff_err[time_idx] = velo_eff_err_tot
+            else:
+                self.results['total'][mode]._start_acq.append(img_time_tot)
+                self.results['total'][mode]._phi.append(phi_tot)
+                self.results['total'][mode]._phi_err.append(phi_err_tot)
+                self.results['total'][mode]._velo_eff.append(velo_eff_tot)
+                self.results['total'][mode]._velo_eff_err.append(velo_eff_err_tot)
 
         # # Ensure the results dictionary is sorted (may not be critical?)
         # sorted_args = np.array(self.results['total'][mode]._start_acq).argsort()


### PR DESCRIPTION
fixes #167 

For `flow_glob` mode, while `vel_glob` is not established the default behaviour in `calculate_emission_rate()` is to  save the col densities, etc to a buffer and add empty values to the results, then `get_cross_corr_emissions_from_buff()` go back through the buffer to process the results. But it appends the results from the buffer instead of updating them. 

This commit the code so that in this case, if a timepoint already exists in the results, then just update the value instead of appending it. 

I don't think the code appending the results is needed, but left anyway just in case there is a case where the value will need to be appended from the buffer. 