### PR TITLE
Issue 213/toggle plumespeeds

### DIFF
--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -1347,33 +1347,39 @@ class TimeSeriesFigure:
         if self.line_plot.lower() != 'none':
             self.plot_bg_roi(marker=self.marker)
             for mode in self.pyplis_worker.velo_modes:
-                if self.pyplis_worker.velo_modes[mode] and getattr(self, mode):
-                    try:
-                        if len(self.pyplis_worker.results[self.line_plot][mode]._phi) > 0:
-                            line_lab = 'line_{}: {}'.format(int(self.line_plot) + 1, mode)
-                            if mode == 'flow_histo':    # Flow dir is reliant on flow_histo (the plot function currently is anyway)
-                                self.plot_flow_dir(self.line_plot, label=line_lab,
-                                                   color=self.colours[int(self.line_plot)],
-                                                   marker='.')
-                            self.plot_veff(self.pyplis_worker.results[self.line_plot][mode],
-                                           label=line_lab, ls=self.plot_styles[mode]['ls'],
-                                           color=self.plot_styles[mode]['colour'],
-                                           # color=self.colours[int(self.line_plot)],
-                                           marker=self.marker,
-                                           markersize=self.Veff_markersize)
-                            self.pyplis_worker.results[self.line_plot][mode].plot(
-                                ax=self.axes[0],
-                                ls=self.plot_styles[mode]['ls'],
-                                color=self.plot_styles[mode]['colour'],
-                                lw=1.5,
-                                ymin=0,
-                                date_fmt=self.date_fmt,
-                                label=line_lab,
-                                marker=self.marker,
-                                markersize=self.ER_markersize,
-                                in_kg=False)
-                    except KeyError:
-                        print('No emission rate analysis data available for {}'.format(self.line_plot))
+                if self.pyplis_worker.velo_modes[mode]:
+                    self.disp_plot_checks[mode].configure(state=tk.ACTIVE)
+                    if getattr(self, mode):
+                        try:
+                            if len(self.pyplis_worker.results[self.line_plot][mode]._phi) > 0:
+                                line_lab = 'line_{}: {}'.format(int(self.line_plot) + 1, mode)
+                                if mode == 'flow_histo':    # Flow dir is reliant on flow_histo (the plot function currently is anyway)
+                                    self.plot_flow_dir(self.line_plot, label=line_lab,
+                                                       color=self.colours[int(self.line_plot)],
+                                                       marker='.')
+                                self.plot_veff(self.pyplis_worker.results[self.line_plot][mode],
+                                               label=line_lab, ls=self.plot_styles[mode]['ls'],
+                                               color=self.plot_styles[mode]['colour'],
+                                               # color=self.colours[int(self.line_plot)],
+                                               marker=self.marker,
+                                               markersize=self.Veff_markersize)
+                                self.pyplis_worker.results[self.line_plot][mode].plot(
+                                    ax=self.axes[0],
+                                    ls=self.plot_styles[mode]['ls'],
+                                    color=self.plot_styles[mode]['colour'],
+                                    lw=1.5,
+                                    ymin=0,
+                                    date_fmt=self.date_fmt,
+                                    label=line_lab,
+                                    marker=self.marker,
+                                    markersize=self.ER_markersize,
+                                    in_kg=False)
+                        except KeyError:
+                            print('No emission rate analysis data available for {}'.format(self.line_plot))
+                else:
+                    self.disp_plot_checks[mode].configure(state=tk.DISABLED)
+
+
 
         # Plot the summed total
         if self.plot_total and len(self.total_lines) > 1:

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -1182,7 +1182,7 @@ class TimeSeriesFigure:
         self.lines = []                     # List holding ids of all lines currently drawn
         self.total_lines = []               # Lines which contribute to the 'total' emission rate
         for key in self.pyplis_worker.velo_modes:
-            setattr(self, '_{}'.format(key), tk.BooleanVar())
+            setattr(self, '_{}'.format(key), tk.BooleanVar(value=True))
 
     @property
     def plot_total(self):
@@ -1269,10 +1269,10 @@ class TimeSeriesFigure:
         plot_check_frame.grid(row=row, column=0, columnspan=4, sticky='nsew')
         self.disp_plot_checks = {}
         for i, key in enumerate(self.pyplis_worker.velo_modes.keys()):
-            self.disp_plot_checks[key] = ttk.Checkbutton(self.plot_check_frame, text=key,
+            self.disp_plot_checks[key] = ttk.Checkbutton(plot_check_frame, text=key,
                                                          variable=getattr(self, '_{}'.format(key)),
                                                          command=self.update_plot)
-            self.disp_plot_checks[key].grid(row=0, column=i, columnspan=2, sticky='w', padx=2, pady=2)
+            self.disp_plot_checks[key].grid(row=0, column=i, sticky='w', padx=2, pady=2)
 
         # Update current line options
         self.update_lines(plot=False)

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -1213,6 +1213,10 @@ class TimeSeriesFigure:
     @flow_glob.setter
     def flow_glob(self, value):
         self._flow_glob.set(value)
+        if value:
+            self.disp_plot_checks['flow_glob'].configure(state=tk.ACTIVE)
+        else:
+            self.disp_plot_checks['flow_glob'].configure(state=tk.DISABLED)
 
     @property
     def flow_nadeau(self):
@@ -1221,6 +1225,10 @@ class TimeSeriesFigure:
     @flow_nadeau.setter
     def flow_nadeau(self, value):
         self._flow_nadeau.set(value)
+        if value:
+            self.disp_plot_checks['flow_nadeau'].configure(state=tk.ACTIVE)
+        else:
+            self.disp_plot_checks['flow_nadeau'].configure(state=tk.DISABLED)
 
     @property
     def flow_raw(self):
@@ -1229,6 +1237,10 @@ class TimeSeriesFigure:
     @flow_raw.setter
     def flow_raw(self, value):
         self._flow_raw.set(value)
+        if value:
+            self.disp_plot_checks['flow_raw'].configure(state=tk.ACTIVE)
+        else:
+            self.disp_plot_checks['flow_raw'].configure(state=tk.DISABLED)
 
     @property
     def flow_histo(self):
@@ -1237,6 +1249,10 @@ class TimeSeriesFigure:
     @flow_histo.setter
     def flow_histo(self, value):
         self._flow_histo.set(value)
+        if value:
+            self.disp_plot_checks['flow_histo'].configure(state=tk.ACTIVE)
+        else:
+            self.disp_plot_checks['flow_histo'].configure(state=tk.DISABLED)
 
     @property
     def flow_hybrid(self):
@@ -1245,6 +1261,10 @@ class TimeSeriesFigure:
     @flow_hybrid.setter
     def flow_hybrid(self, value):
         self._flow_hybrid.set(value)
+        if value:
+            self.disp_plot_checks['flow_hybrid'].configure(state=tk.ACTIVE)
+        else:
+            self.disp_plot_checks['flow_hybrid'].configure(state=tk.DISABLED)
 
     def _build_opts(self):
         """Builds options widget"""
@@ -1347,39 +1367,33 @@ class TimeSeriesFigure:
         if self.line_plot.lower() != 'none':
             self.plot_bg_roi(marker=self.marker)
             for mode in self.pyplis_worker.velo_modes:
-                if self.pyplis_worker.velo_modes[mode]:
-                    self.disp_plot_checks[mode].configure(state=tk.ACTIVE)
-                    if getattr(self, mode):
-                        try:
-                            if len(self.pyplis_worker.results[self.line_plot][mode]._phi) > 0:
-                                line_lab = 'line_{}: {}'.format(int(self.line_plot) + 1, mode)
-                                if mode == 'flow_histo':    # Flow dir is reliant on flow_histo (the plot function currently is anyway)
-                                    self.plot_flow_dir(self.line_plot, label=line_lab,
-                                                       color=self.colours[int(self.line_plot)],
-                                                       marker='.')
-                                self.plot_veff(self.pyplis_worker.results[self.line_plot][mode],
-                                               label=line_lab, ls=self.plot_styles[mode]['ls'],
-                                               color=self.plot_styles[mode]['colour'],
-                                               # color=self.colours[int(self.line_plot)],
-                                               marker=self.marker,
-                                               markersize=self.Veff_markersize)
-                                self.pyplis_worker.results[self.line_plot][mode].plot(
-                                    ax=self.axes[0],
-                                    ls=self.plot_styles[mode]['ls'],
-                                    color=self.plot_styles[mode]['colour'],
-                                    lw=1.5,
-                                    ymin=0,
-                                    date_fmt=self.date_fmt,
-                                    label=line_lab,
-                                    marker=self.marker,
-                                    markersize=self.ER_markersize,
-                                    in_kg=False)
-                        except KeyError:
-                            print('No emission rate analysis data available for {}'.format(self.line_plot))
-                else:
-                    self.disp_plot_checks[mode].configure(state=tk.DISABLED)
-
-
+                if self.pyplis_worker.velo_modes[mode] and getattr(self, mode):
+                    try:
+                        if len(self.pyplis_worker.results[self.line_plot][mode]._phi) > 0:
+                            line_lab = 'line_{}: {}'.format(int(self.line_plot) + 1, mode)
+                            if mode == 'flow_histo':    # Flow dir is reliant on flow_histo (the plot function currently is anyway)
+                                self.plot_flow_dir(self.line_plot, label=line_lab,
+                                                   color=self.colours[int(self.line_plot)],
+                                                   marker='.')
+                            self.plot_veff(self.pyplis_worker.results[self.line_plot][mode],
+                                           label=line_lab, ls=self.plot_styles[mode]['ls'],
+                                           color=self.plot_styles[mode]['colour'],
+                                           # color=self.colours[int(self.line_plot)],
+                                           marker=self.marker,
+                                           markersize=self.Veff_markersize)
+                            self.pyplis_worker.results[self.line_plot][mode].plot(
+                                ax=self.axes[0],
+                                ls=self.plot_styles[mode]['ls'],
+                                color=self.plot_styles[mode]['colour'],
+                                lw=1.5,
+                                ymin=0,
+                                date_fmt=self.date_fmt,
+                                label=line_lab,
+                                marker=self.marker,
+                                markersize=self.ER_markersize,
+                                in_kg=False)
+                    except KeyError:
+                        print('No emission rate analysis data available for {}'.format(self.line_plot))
 
         # Plot the summed total
         if self.plot_total and len(self.total_lines) > 1:
@@ -5068,6 +5082,7 @@ class OptiFlowSettings(LoadSaveProcessingSettings):
         self.pyplis_worker = pyplis_work
         self.pyplis_worker.fig_opt = self
         self.fig_SO2 = None
+        self.fig_time_series = None
         self.q = queue.Queue()
         self.cam_specs = cam_specs
         self.fig_setts = fig_setts
@@ -5451,6 +5466,7 @@ class OptiFlowSettings(LoadSaveProcessingSettings):
         # Loop through flow options and set them
         for key in self.pyplis_worker.velo_modes:
             self.pyplis_worker.config[key] = bool(getattr(self, key))
+            setattr(self.fig_time_series, key, bool(getattr(self, key)))  # Update timeseires fig too
 
         non_opt_flow_setts = self.vars.keys() - self.settings_vars
 

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -39,6 +39,7 @@ import threading
 from pandas import Series
 import io
 import pickle
+import copy
 
 refresh_rate = 200    # Refresh rate of draw command when in processing thread
 
@@ -1156,6 +1157,7 @@ class TimeSeriesFigure:
                             'flow_histo': {'ls': 'dashed', 'marker': '2', 'colour': 'darkmagenta'},
                             'flow_hybrid': {'ls': 'dashdot', 'marker': '3', 'colour': 'fuchsia'}
                             }
+        self.disp_plot = copy.deepcopy(self.pyplis_worker.velo_modes)   # Dictionary of which velocity modes to display in plot
         self.colours = self.pyplis_worker.fig_tau.line_colours
         self.marker = '.'
         self.ER_markersize = 3
@@ -1290,7 +1292,7 @@ class TimeSeriesFigure:
 
         if self.line_plot.lower() != 'none':
             for mode in self.pyplis_worker.velo_modes:
-                if self.pyplis_worker.velo_modes[mode]:
+                if self.pyplis_worker.velo_modes[mode] and self.disp_plot[mode]:
                     try:
                         if len(self.pyplis_worker.results[self.line_plot][mode]._phi) > 0:
                             line_lab = 'line_{}: {}'.format(int(self.line_plot) + 1, mode)

--- a/pycam/gui/figures_analysis.py
+++ b/pycam/gui/figures_analysis.py
@@ -1182,6 +1182,8 @@ class TimeSeriesFigure:
         self.plot_total = 1
         self.lines = []                     # List holding ids of all lines currently drawn
         self.total_lines = []               # Lines which contribute to the 'total' emission rate
+        for key in self.disp_plot:
+            setattr(self, key, tk.BooleanVar())
 
     @property
     def plot_total(self):
@@ -1205,20 +1207,71 @@ class TimeSeriesFigure:
     def line_plot(self, value):
         self._line_plot.set(value)
 
+    @property
+    def flow_glob(self):
+        return self._flow_glob.get()
+
+    @flow_glob.setter
+    def flow_glob(self, value):
+        self._flow_glob.set(value)
+
+    @property
+    def flow_nadeau(self):
+        return self._flow_nadeau.get()
+
+    @flow_nadeau.setter
+    def flow_nadeau(self, value):
+        self._flow_nadeau.set(value)
+
+    @property
+    def flow_raw(self):
+        return self._flow_raw.get()
+
+    @flow_raw.setter
+    def flow_raw(self, value):
+        self._flow_raw.set(value)
+
+    @property
+    def flow_histo(self):
+        return self._flow_histo.get()
+
+    @flow_histo.setter
+    def flow_histo(self, value):
+        self._flow_histo.set(value)
+
+    @property
+    def flow_hybrid(self):
+        return self._flow_hybrid.get()
+
+    @flow_hybrid.setter
+    def flow_hybrid(self, value):
+        self._flow_hybrid.set(value)
+
     def _build_opts(self):
         """Builds options widget"""
         self.opts_frame = ttk.LabelFrame(self.frame, text='Options')
 
+        row = 0
         lab = ttk.Label(self.opts_frame, text='Plot line:', font=self.main_gui.main_font)
-        lab.grid(row=0, column=0, sticky='w', padx=2, pady=2)
+        lab.grid(row=row, column=0, sticky='w', padx=2, pady=2)
         self.line_opts = ttk.Combobox(self.opts_frame, textvariable=self._line_plot, justify='left',
                                       state='readonly', font=self.main_gui.main_font)
         self.line_opts.bind('<<ComboboxSelected>>', self.update_plot)
-        self.line_opts.grid(row=0, column=1, sticky='nsew', padx=2, pady=2)
+        self.line_opts.grid(row=row, column=1, sticky='nsew', padx=2, pady=2)
 
+        row += 1
         self.plt_tot_check = ttk.Checkbutton(self.opts_frame, text='Plot sum of all lines', variable=self._plot_total,
                                              command=self.update_plot)
-        self.plt_tot_check.grid(row=1, column=0, columnspan=2, sticky='w', padx=2, pady=2)
+        self.plt_tot_check.grid(row=row, column=0, columnspan=2, sticky='w', padx=2, pady=2)
+
+        # Options for toggling different velocity plot on and off
+        row += 1
+        self.disp_plot_checks = {}
+        for i, key in enumerate(self.disp_plot.keys()):
+            self.disp_plot_checks[key] = ttk.Checkbutton(self.opts_frame, text=key,
+                                                         variable=getattr(self, '_{}'.format(key)),
+                                                         command=self.update_plot)
+            self.disp_plot_checks[key].grid(row=row, column=i, columnspan=2, sticky='w', padx=2, pady=2)
 
         # Update current line options
         self.update_lines(plot=False)

--- a/pycam/gui/pycam_gui.py
+++ b/pycam/gui/pycam_gui.py
@@ -115,6 +115,7 @@ class PyCam(ttk.Frame):
         cross_correlation.initiate_variables(self)
         nadeau_flow.start_draw(self.root)
         nadeau_flow.initiate_variables(self)
+        opti_flow.fig_time_series = self.anal_wind.time_series
         opti_flow.initiate_variables(self)
         light_dilution.add_gui(self)
         light_dilution.initiate_variables()


### PR DESCRIPTION
Fixes #213.

Options now available to toggle the display of different plume speeds off and on in the time series figure. And these options are disabled if a certain plume speed algorithm is not currently being generated.