### PR TITLE
Pyproject dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,29 +5,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pycam"
 version = "0.0.1"
-dependencies = [
-    "astropy==5.2.1",
-    "geonum==1.4.5",
-    "LatLon23",
-    "matplotlib==3.5",
-    "numpy==1.23",
-    "opencv-python",
-    "pandas==1.5.3",
-    "paramiko==3.1.0",
-#    "picamera==1.13",
-    "Pillow==9.4.0",
-    "pydoas==1.2.4",
-#    "pyinotify==0.9.6",
-    "scipy==1.10.1",
-#    "seabreeze==2.0.3",
-    "Shapely==2.0.1",
-    "ttkthemes==3.2.2",
-    "scikit-image==0.18.3",
-    "srtm.py",
-    "watchdog",
-    "pyplis @ git+https://github.com/ubdbra001/pyplis.git@sources_fix",
-    "iFit @ git+https://github.com/ubdbra001/iFit.git@make-pip-install",
-]
 
 [tool.setuptools]
 packages = ["pycam"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ['requirements.txt']}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pycam"
 version = "0.0.1"
+dynamic = ["dependencies"]
 
 [tool.setuptools]
 packages = ["pycam"]


### PR DESCRIPTION
Instead of having the requirements both in the requirements.txt and the pyproject.toml, we can get pyproject.toml to reference the requirements file. 

This should save us from having to keep both lists up to date with any changes.